### PR TITLE
OC-5702: Tags in the Rule template should include opening and closing tags for messages

### DIFF
--- a/core/src/main/resources/properties/rules_template.xml
+++ b/core/src/main/resources/properties/rules_template.xml
@@ -9,7 +9,7 @@
 			<EmailAction IfExpressionEvaluates="">
 				<Run AdministrativeDataEntry="true" InitialDataEntry="true" DoubleDataEntry="true" ImportDataEntry="false" Batch="true" />
                 <Message></Message>
-				<To/>
+                <To></To>
 			</EmailAction>
 			<ShowAction IfExpressionEvaluates="">
 				<Run AdministrativeDataEntry="true" InitialDataEntry="true" DoubleDataEntry="true" ImportDataEntry="false" Batch="false" />


### PR DESCRIPTION
Tags in the Rule template should include opening and closing tags for messages
