### PR TITLE
OC-5933 Date filters no longer work on Notes and Discrepancies Table 

### DIFF
--- a/core/src/main/resources/queries/postgres/viewnotes.properties
+++ b/core/src/main/resources/queries/postgres/viewnotes.properties
@@ -12,8 +12,8 @@ findAllDiscrepancyNotes.filter.label=and label like :label
 findAllDiscrepancyNotes.filter.discrepancy_note_type_id=and discrepancy_note_type_id in ( :discrepancy_note_type_id )
 findAllDiscrepancyNotes.filter.resolution_status_id=and resolution_status_id in ( :resolution_status_id )
 findAllDiscrepancyNotes.filter.site_id=and site_id like :site_id
-findAllDiscrepancyNotes.filter.date_created=and date_created = :date_created
-findAllDiscrepancyNotes.filter.date_updated=and date_updated = :date_updated
+findAllDiscrepancyNotes.filter.date_created=and date(date_created) = :date_created
+findAllDiscrepancyNotes.filter.date_updated=and date(date_updated) = :date_updated
 findAllDiscrepancyNotes.filter.days=and days = :days
 findAllDiscrepancyNotes.filter.age=and age = :age
 findAllDiscrepancyNotes.filter.event_name=and event_name like :event_name


### PR DESCRIPTION
Date filters no longer work on Notes and Discrepancies Table 
pushing in the fix/implementation of this bug
