### PR TITLE
OC-5937 Update property file to be blank for PForm URL value

### DIFF
--- a/web/src/main/resources/datainfo.properties
+++ b/web/src/main/resources/datainfo.properties
@@ -327,8 +327,8 @@ ldap.userData.email=mail
 ldap.userData.organization=company
 
 ####################################################################
-Participal Portal
+Participant Portal
 ####################################################################
-# To connect to Participal Portal , use the below URL
-portalURL = http://localhost:8080/epro/
+# To connect to Participant Portal , use the below URL
+portalURL =
 ##################################################################


### PR DESCRIPTION
Update property file to be blank for PForm URL value
updated the datainfo.property file by removing the participant portal url 
