### PR TITLE
OC-6001 When updating an item in a crf , AL record misses out to record study_event_id and crf_version_id component in AL table

### DIFF
--- a/core/src/main/resources/migration/2.5/changeLogCreateFunctions.xml
+++ b/core/src/main/resources/migration/2.5/changeLogCreateFunctions.xml
@@ -175,11 +175,12 @@
 				IF(OLD.value <![CDATA[<>]]> NEW.value) THEN
 				/*---------------*/
 				 /*Item data updated*/
-				SELECT INTO pk NEXTVAL(''audit_log_event_audit_id_seq'');
+                SELECT INTO pk NEXTVAL(''audit_log_event_audit_id_seq'');
 				SELECT INTO entity_name_value item.name FROM item WHERE item.item_id = NEW.item_id;
-				INSERT INTO audit_log_event(audit_id, audit_log_event_type_id, audit_date, user_id, audit_table, entity_id, entity_name, old_value, new_value, event_crf_id)
-					VALUES (pk, ''1'', now(), NEW.update_id, ''item_data'', NEW.item_data_id, entity_name_value, OLD.value, NEW.value, NEW.event_crf_id);
-				/*---------------*/
+		        SELECT INTO std_evnt_id ec.study_event_id FROM event_crf ec WHERE ec.event_crf_id = OLD.event_crf_id;
+		        SELECT INTO crf_version_id ec.crf_version_id FROM event_crf ec WHERE ec.event_crf_id = OLD.event_crf_id;
+				INSERT INTO audit_log_event(audit_id, audit_log_event_type_id, audit_date, user_id, audit_table, entity_id, entity_name, old_value, new_value, event_crf_id, study_event_id, event_crf_version_id)
+					VALUES (pk, ''1'', now(), NEW.update_id, ''item_data'', NEW.item_data_id, entity_name_value, OLD.value, NEW.value, NEW.event_crf_id, std_evnt_id, crf_version_id);				/*---------------*/
 				END IF;
 				RETURN NULL;  /*return values ignored for ''after'' triggers*/
 			END IF;


### PR DESCRIPTION
When updating an item in a crf , AL record misses out to record
study_event_id and crf_version_id component in AL table
Commiting fix for this issue
