### PR TITLE
Fixing not updating Japanese choices on select box

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/CreateStudyServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/CreateStudyServlet.java
@@ -1018,7 +1018,13 @@ public class CreateStudyServlet extends SecureController {
     private void updateMaps() {
         if (current_maps_locale != resadmin.getLocale()) {
             current_maps_locale = resadmin.getLocale();
-            facRecruitStatusMap.put("not_yet_recruiting", resadmin.getString("not_yet_recruiting"));
+            updateMaps2();
+
+     	}
+    }
+    
+    public static void updateMaps2() {
+    	    facRecruitStatusMap.put("not_yet_recruiting", resadmin.getString("not_yet_recruiting"));
             facRecruitStatusMap.put("recruiting", resadmin.getString("recruiting"));
             facRecruitStatusMap.put("no_longer_recruiting", resadmin.getString("no_longer_recruiting"));
             facRecruitStatusMap.put("completed", resadmin.getString("completed"));
@@ -1086,9 +1092,9 @@ public class CreateStudyServlet extends SecureController {
 
             timingMap.put("retrospective", resadmin.getString("retrospective"));
             timingMap.put("prospective", resadmin.getString("prospective"));
-        }
-    }
+    }    	
 
+    
     @Override
     protected String getAdminServlet() {
         return SecureController.ADMIN_SERVLET_CODE;

--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/UpdateStudyServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/UpdateStudyServlet.java
@@ -667,6 +667,7 @@ public class UpdateStudyServlet extends SecureController {
      * @param isInterventional
      */
     private void setMaps(boolean isInterventional, ArrayList interventionArray) {
+    	CreateStudyServlet.updateMaps2();
         if (isInterventional) {
             request.setAttribute("interPurposeMap", CreateStudyServlet.interPurposeMap);
             request.setAttribute("allocationMap", CreateStudyServlet.allocationMap);

--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/UpdateStudyServletNew.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/UpdateStudyServletNew.java
@@ -469,6 +469,7 @@ public class UpdateStudyServletNew extends SecureController {
     }
 
     private void setMaps(boolean isInterventional, ArrayList interventionArray) {
+    	CreateStudyServlet.updateMaps2();
         if (isInterventional) {
             request.setAttribute("interPurposeMap", CreateStudyServlet.interPurposeMap);
             request.setAttribute("allocationMap", CreateStudyServlet.allocationMap);


### PR DESCRIPTION
This commit fixes a problem discussed in
https://www.openclinica.com/forums#/discussion/15461

In summary, when OpenClinica runs on non-english locales on server and
users prefer English on their browser, choices of select box in “Create
Study” or “Update Study Details” are displayed in non-English language.
This is caused by lack of code which will update HashMaps of
internationalized resources.
