### PR TITLE
OC-6201 PForm: Data not saved correctly if Single-select Pull Down item with long string and/or contains comma 

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/web/pform/OpenRosaXmlGenerator.java
+++ b/web/src/main/java/org/akaza/openclinica/web/pform/OpenRosaXmlGenerator.java
@@ -556,6 +556,7 @@ public class OpenRosaXmlGenerator {
 		Reader reader = new StringReader(content);
 		Unmarshaller unmarshaller = xmlContext.createUnmarshaller();
 		unmarshaller.setClass(Html.class);
+		unmarshaller.setWhitespacePreserve(false);
 		Html html = (Html) unmarshaller.unmarshal(reader);
 		reader.close();
 		return html;


### PR DESCRIPTION
checking in fix code for this reported bug
I'm removing the white spaces for item labels and values