### PR TITLE
Update global_functions_javascript.js

### DIFF
--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/signStudySubject.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/signStudySubject.jsp
@@ -431,9 +431,10 @@
 <%-- Subject discrepancy note table--%>
 <div id="subjDiscNoteDivTitle" class="subjDiscNoteDivTitle">
     <a id="discNoteDivParent" href="javascript:void(0)"
-       onclick="showSummaryBox(document.getElementById('subjDiscNoteDiv'),document.getElementById('discNoteDivParent'),'<fmt:message key="show_event_notes" bundle="${resword}"/>','<fmt:message key="hide_event_notes" bundle="${resword}"/>')"><fmt:message key="show_event_notes" bundle="${resword}"/></a>
+       onclick="showSummaryBox('subjDiscNoteDiv',document.getElementById('discNoteDivParent'),'<fmt:message key="show_event_notes" bundle="${resword}"/>','<fmt:message key="hide_event_notes" bundle="${resword}"/>')"><fmt:message key="show_event_notes" bundle="${resword}"/></a>
 </div>
-<div id="subjDiscNoteDiv" class="subjDiscNoteDiv" style="display:none">
+<%--<div id="subjDiscNoteDiv" class="subjDiscNoteDiv" style="display:none">--%>
+    <div id="subjDiscNoteDiv" class="subjDiscNoteDiv">
     <table class="subjDiscNoteTable" cellpadding="0" cellspacing="0">
         <thead>
             <th class="table_header_row_left">Event Name</th>

--- a/web/src/main/webapp/includes/global_functions_javascript.js
+++ b/web/src/main/webapp/includes/global_functions_javascript.js
@@ -343,7 +343,12 @@ function setNewIconInParentWin(idOfImageElement, imageLocation){
 }
 function showSummaryBox(divObject,parentLinkObj,showText,hideText){
     //var sumBox = $(divObject);
-    var sumBox = document.getElementById(divObject);
+    var sumBox;
+ 
+    if (typeof divObject === 'string') //Check if divObject is the actual element or its ID
+        sumBox = document.getElementById(divObject);
+    else
+        sumBox = $(divObject);
     if(sumBox && sumBox.style.display == "none") {
 
 //        sumBox.show();


### PR DESCRIPTION
function showSummaryBox(divObject,parentLinkObj,showText,hideText) is called though OC’s code passing divObject as an actual element or the ID of an element.

The old function code had two different variable declarations to handle the two different calling scenarios:

     //var sumBox = $(divObject);

     var sumBox = document.getElementById(divObject);

Obviously this cannot work for both scenarios, without manually commenting and uncommenting the two lines (e.g. on page OpenClinica/SignStudySubject the link “Show events and discrepancy notes” is not functional).

The altered code is first checking to see if divObject is an element or its ID and then is declaring sumBox accordingly.

![signstudysubject01](https://cloud.githubusercontent.com/assets/10481651/7856077/942e68cc-0526-11e5-954e-e204c89bffab.PNG)
![signstudysubject02](https://cloud.githubusercontent.com/assets/10481651/7856119/fb25fd06-0526-11e5-97ae-c9d7d1accbed.PNG)