### PR TITLE
OC-5754 Rule Designer: For EventAction, If there is more than one Eve…

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/domain/rule/action/RuleActionComparator.java
+++ b/core/src/main/java/org/akaza/openclinica/domain/rule/action/RuleActionComparator.java
@@ -14,7 +14,7 @@ public class RuleActionComparator implements Comparator<RuleActionBean> {
         order.put(ActionType.SHOW, "3");
         order.put(ActionType.HIDE, "4");
         order.put(ActionType.INSERT, "5");
-
+        order.put(ActionType.EVENT, "6");
     }
 
     public int compare(RuleActionBean o1, RuleActionBean o2) {


### PR DESCRIPTION
…ntAction added to a target, RD crashes.

It's just missing an enum ActionType.EVENT on the OC-side, so I just added that one-liner fix
