### PR TITLE
Update global_functions_javascript.js

### DIFF
--- a/web/src/main/webapp/includes/global_functions_javascript.js
+++ b/web/src/main/webapp/includes/global_functions_javascript.js
@@ -343,7 +343,12 @@ function setNewIconInParentWin(idOfImageElement, imageLocation){
 }
 function showSummaryBox(divObject,parentLinkObj,showText,hideText){
     //var sumBox = $(divObject);
-    var sumBox = document.getElementById(divObject);
+    //var sumBox = document.getElementById(divObject);
+    var sumBox;
+    if (typeof divObject === 'string')
+        sumBox = document.getElementById(divObject);
+    else
+        sumBox = $(divObject);
     if(sumBox && sumBox.style.display == "none") {
 
 //        sumBox.show();


### PR DESCRIPTION
(Please also see pull request #195)

Function showSummaryBox(divObject,parentLinkObj,showText,hideText) is called though OC’s code passing divObject as an actual element or the ID of an element.

The old function code had two different variable declarations to handle the two different calling scenarios:
 //var sumBox = $(divObject);

 var sumBox = document.getElementById(divObject);

Obviously this cannot work for both scenarios, without manually commenting and uncommenting the two lines (e.g. on page OpenClinica/SignStudySubject the link “Show events and discrepancy notes” is not functional).

The altered code is first checking to see if divObject is an element or its ID and then is declaring sumBox accordingly.

![signstudysubject01](https://cloud.githubusercontent.com/assets/10481651/7856354/b829e8da-0528-11e5-89a1-c4f8e6f90a6b.PNG)
![signstudysubject02](https://cloud.githubusercontent.com/assets/10481651/7856362/ba721fa4-0528-11e5-8ede-7f296cbce3fe.PNG)
