### PR TITLE
Update signStudySubject.jsp

### DIFF
--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/signStudySubject.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/signStudySubject.jsp
@@ -431,7 +431,7 @@
 <%-- Subject discrepancy note table--%>
 <div id="subjDiscNoteDivTitle" class="subjDiscNoteDivTitle">
     <a id="discNoteDivParent" href="javascript:void(0)"
-       onclick="showSummaryBox(document.getElementById('subjDiscNoteDiv'),document.getElementById('discNoteDivParent'),'<fmt:message key="show_event_notes" bundle="${resword}"/>','<fmt:message key="hide_event_notes" bundle="${resword}"/>')"><fmt:message key="show_event_notes" bundle="${resword}"/></a>
+       onclick="showSummaryBox('subjDiscNoteDiv',document.getElementById('discNoteDivParent'),'<fmt:message key="show_event_notes" bundle="${resword}"/>','<fmt:message key="hide_event_notes" bundle="${resword}"/>')"><fmt:message key="show_event_notes" bundle="${resword}"/></a>
 </div>
 <div id="subjDiscNoteDiv" class="subjDiscNoteDiv" style="display:none">
     <table class="subjDiscNoteTable" cellpadding="0" cellspacing="0">


### PR DESCRIPTION
On pull request #194 I’m proposing an update to the showSummaryBox js function to be able to handle both elements and elemants IDs.

Alternative, if you prefer to keep global_functions_javascript.js intact, you can update the signStudySubject.jsp file and call the function showSummaryBox in the correct way (passing element ID, not the element).

I am also suggesting that the discrepancy notes should be displayed by default, since the information that it contains is vital for many SOP’s. Therefor, link 436 should be changed from:

```
<div id="subjDiscNoteDiv" class="subjDiscNoteDiv" style="display:none">
```

to

```
<div id="subjDiscNoteDiv" class="subjDiscNoteDiv">
```
