### PR TITLE
remove null-study check from OpenRosaServices.java

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/web/pform/OpenRosaServices.java
+++ b/web/src/main/java/org/akaza/openclinica/web/pform/OpenRosaServices.java
@@ -75,7 +75,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.servlet.mvc.multiaction.NoSuchRequestHandlingMethodException;
 import org.akaza.openclinica.service.PformSubmissionService;
 import org.akaza.openclinica.service.pmanage.ParticipantPortalRegistrar;
 import org.akaza.openclinica.service.pmanage.Study;
@@ -564,11 +563,9 @@ public class OpenRosaServices {
         return studyBean;
     }
 
-    private StudyBean getParentStudy(String studyOid) throws NoSuchRequestHandlingMethodException {
+    private StudyBean getParentStudy(String studyOid) {
         StudyBean study = getStudy(studyOid);
-        if (study == null) {
-            throw new NoSuchRequestHandlingMethodException("getParentStudy", OpenRosaServices.class);
-        } else if (study.getParentStudyId() == 0) {
+        if (study.getParentStudyId() == 0) {
             return study;
         } else {
             StudyBean parentStudy = (StudyBean) sdao.findByPK(study.getParentStudyId());


### PR DESCRIPTION
revert the NoSuchRequestMethodHandlingException throwing when study is null from OpenRosaServices.getParentStudy()