### PR TITLE
OC-3334 MainMenu incorrectly uses full URI

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/dao/core/CoreResources.java
+++ b/core/src/main/java/org/akaza/openclinica/dao/core/CoreResources.java
@@ -7,6 +7,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -295,6 +296,7 @@ public class CoreResources implements ResourceLoaderAware {
         // sysURL.base
         String sysURLBase = DATAINFO.getProperty("sysURL").replace("MainMenu", "");
         DATAINFO.setProperty("sysURL.base", sysURLBase);
+        DATAINFO.setProperty("sysURL.basePath", URI.create(sysURLBase).getPath());
 
         if (DATAINFO.getProperty("org.quartz.jobStore.misfireThreshold") == null)
             DATAINFO.setProperty("org.quartz.jobStore.misfireThreshold", "60000");

--- a/web/src/main/webapp/WEB-INF/jsp/include/createDatasetSide.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/createDatasetSide.jsp
@@ -3,6 +3,8 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 <fmt:setBundle basename="org.akaza.openclinica.i18n.words" var="resword"/>
+<jsp:useBean scope='request' id='coreResources' class='org.akaza.openclinica.dao.core.CoreResources' />
+<c:set var="basePath" value="${coreResources.getField('sysURL.basePath')}" />
 
 <c:choose>
 <c:when test="${panel.orderedData}">
@@ -28,10 +30,10 @@
                     <c:set var="eventCount" value="${eventCount+1}"/>
                     <tr>
                         <td valign="top" width="10" class="leftmenu"><a href="javascript:leftnavExpand('leftnavSubRow_SubSection<c:out value="${eventCount}"/>');
-		          javascript:setImage('ExpandGroup<c:out value="${eventCount}"/>','images/bt_Collapse.gif');"><img
-                          name="ExpandGroup<c:out value="${eventCount}"/>" src="images/bt_Expand.gif" border="0"></a></td>
+		          javascript:setImage('ExpandGroup<c:out value="${eventCount}"/>','<c:out value="${basePath}"/>images/bt_Collapse.gif');"><img
+                          name="ExpandGroup<c:out value="${eventCount}"/>" src="${basePath}images/bt_Expand.gif" border="0"></a></td>
                         <td valign="top" class="leftmenu"><a href="javascript:leftnavExpand('leftnavSubRow_SubSection<c:out value="${eventCount}"/>');
-		            javascript:setImage('ExpandGroup<c:out value="${eventCount}"/>','images/bt_Collapse.gif');"><b><c:out value="${line.info}" escapeXml="false"/></b></a>
+		            javascript:setImage('ExpandGroup<c:out value="${eventCount}"/>','<c:out value="${basePath}"/>images/bt_Collapse.gif');"><b><c:out value="${line.info}" escapeXml="false"/></b></a>
                         </td>
                     </tr>
                 </c:when>
@@ -54,13 +56,13 @@
                 <c:choose>
                     <c:when test="${line.lastCRF}">
                         <td valign="top" class="vline_B">
-                            <img src="images/leftbar_hline.gif"></td>
+                            <img src="${basePath}images/leftbar_hline.gif"></td>
                         <td valign="top" class="leftmenu" style="font-size:11px; color:#789EC5"><c:out value="${line.info}" escapeXml="false"/></td>
                     </c:when>
                     <c:otherwise>
                         <c:if test="${line.title=='CRF'}">
                             <td valign="top" class="vline">
-                                <img src="images/leftbar_hline.gif"></td>
+                                <img src="${basePath}images/leftbar_hline.gif"></td>
                             <td valign="top" class="leftmenu" style="font-size:11px; color:#789EC5"><c:out value="${line.info}" escapeXml="false"/></td>
                         </c:if>
                     </c:otherwise>
@@ -76,16 +78,16 @@
         </table>
     </c:if>
 
-    <br><a href='SelectItems?eventAttr=1'><b><fmt:message key="event_attributes" bundle="${resword}"/></b></a><br><br>
-    <a href='SelectItems?subAttr=1'><b><fmt:message key="subject_attributes" bundle="${resword}"/></b></a><br><br>
-    <a href='SelectItems?CRFAttr=1'><b>CRF Attributes</b></a><br><br>
-    <a href='SelectItems?groupAttr=1'><b>Group Attributes</b></a><br><br>
+    <br><a href='${basePath}SelectItems?eventAttr=1'><b><fmt:message key="event_attributes" bundle="${resword}"/></b></a><br><br>
+    <a href='${basePath}SelectItems?subAttr=1'><b><fmt:message key="subject_attributes" bundle="${resword}"/></b></a><br><br>
+    <a href='${basePath}SelectItems?CRFAttr=1'><b>CRF Attributes</b></a><br><br>
+    <a href='${basePath}SelectItems?groupAttr=1'><b>Group Attributes</b></a><br><br>
     <%--
-        <a href='SelectItems?discAttr=1'><b>Discrepancy Note Attributes</b></a><br><br>
+        <a href='${basePath}SelectItems?discAttr=1'><b>Discrepancy Note Attributes</b></a><br><br>
     --%>
-    <a href='ViewSelected'><b><fmt:message key="view_selected_items" bundle="${resword}"/></b></a>
+    <a href='${basePath}ViewSelected'><b><fmt:message key="view_selected_items" bundle="${resword}"/></b></a>
     <br /><br>
-    <form id="selectAllItems" action="EditSelected" method="post" name="selectAllItems">
+    <form id="selectAllItems" action="${basePath}EditSelected" method="post" name="selectAllItems">
         <input type="hidden" name="all" value="1">
     </form>
 
@@ -102,7 +104,7 @@
     </c:if>
     <a href="javascript: openDocWindow('ViewSelected?status=html')"><b><fmt:message key="view_selected_items" bundle="${resword}"/></b></a><br />
     <br>
-    <form id="selectAllItems" action="EditSelected" method="post" name="selectAllItems">
+    <form id="selectAllItems" action="${basePath}EditSelected" method="post" name="selectAllItems">
         <input type="hidden" name="all" value="1">
     </form>
      <c:if test="${! EditSelectedSubmitted}"><a href='javascript:void 0' onclick="if(confirm('<fmt:message key="there_a_total_of" bundle="${resword}"><fmt:param value="${numberOfStudyItems}"/></fmt:message>')){document.getElementById('selectAllItems').submit();}"><b><fmt:message key="select_all_items_in_study" bundle="${resword}"/></b></a>

--- a/web/src/main/webapp/WEB-INF/jsp/include/footer.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/footer.jsp
@@ -1,16 +1,19 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
  
 <fmt:setBundle basename="org.akaza.openclinica.i18n.words" var="resword"/>
 <fmt:setBundle basename="org.akaza.openclinica.i18n.licensing" var="licensing"/>
- 
+<jsp:useBean scope='request' id='coreResources' class='org.akaza.openclinica.dao.core.CoreResources' />
+<c:set var="basePath" value="${coreResources.getField('sysURL.basePath')}" />
+
 <!-- END MAIN CONTENT AREA -->
 </td>
             </tr>
         </table></td></tr></table>
         
-<script type="text/javascript" src="${pageContext.request.contextPath}/includes/wz_tooltip/wz_tooltip.js"></script>
+<script type="text/javascript" src="${basePath}includes/wz_tooltip/wz_tooltip.js"></script>
 <table border="0" cellpadding="0" width="100%"  >
             <tr>
                 <td class="footer_bottom" style="width:200px">
@@ -18,8 +21,8 @@
                 &nbsp;&nbsp;&nbsp;
                 <a href="javascript:openDocWindow('https://docs.openclinica.com/3.1')"><fmt:message key="help" bundle="${resword}"/></a>
                 &nbsp;&nbsp;&nbsp;
-           <%-->     <a href="${pageContext.request.contextPath}Contact"><fmt:message key="contact" bundle="${resword}"/></a>--%>
-             <a href="${pageContext.request.contextPath}/Contact"><fmt:message key="contact" bundle="${resword}"/></a>
+           <%-->     <a href="${basePath}Contact"><fmt:message key="contact" bundle="${resword}"/></a>--%>
+             <a href="${basePath}Contact"><fmt:message key="contact" bundle="${resword}"/></a>
           
                 </td>
                 <td class="footer_bottom" >
@@ -41,7 +44,7 @@
         </table>
 
 <!-- End Footer -->
-<link rel="shortcut icon" type="image/x-icon" href="${pageContext.request.contextPath}/images/favicon.ico">
+<link rel="shortcut icon" type="image/x-icon" href="${basePath}images/favicon.ico">
 
         
 

--- a/web/src/main/webapp/WEB-INF/jsp/include/home-header.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/home-header.jsp
@@ -10,37 +10,38 @@
 <jsp:useBean scope='session' id='study' class='org.akaza.openclinica.bean.managestudy.StudyBean' />
 <jsp:useBean scope='session' id='userRole' class='org.akaza.openclinica.bean.login.StudyUserRoleBean' />
 <jsp:useBean scope='request' id='isAdminServlet' class='java.lang.String' />
+<jsp:useBean scope='request' id='coreResources' class='org.akaza.openclinica.dao.core.CoreResources' />
+<c:set var="basePath" value="${coreResources.getField('sysURL.basePath')}" />
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-<c:set var="contextPath" value="${fn:replace(pageContext.request.requestURL, fn:substringAfter(pageContext.request.requestURL, pageContext.request.contextPath), '')}" />
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=8" />
 
 
 <title><fmt:message key="openclinica" bundle="${resword}"/></title>
 
-<link rel="stylesheet" href="<c:out value="${contextPath}" />/includes/styles.css" type="text/css"/>
-<%-- <link rel="stylesheet" href="includes/styles2.css" type="text/css">--%>
-<%-- <link rel="stylesheet" href="includes/NewNavStyles.css" type="text/css" />--%>
-<script type="text/JavaScript" language="JavaScript" src="includes/global_functions_javascript.js"></script>
-<%-- <script type="text/JavaScript" language="JavaScript" src="includes/global_functions_javascript2.js"></script> --%>
-<script type="text/JavaScript" language="JavaScript" src="includes/Tabs.js"></script>
-<script type="text/JavaScript" language="JavaScript" src="includes/CalendarPopup.js"></script>
+<link rel="stylesheet" href="${basePath}includes/styles.css" type="text/css"/>
+<%-- <link rel="stylesheet" href="${basePath}includes/styles2.css" type="text/css">--%>
+<%-- <link rel="stylesheet" href="${basePath}includes/NewNavStyles.css" type="text/css" />--%>
+<script type="text/JavaScript" language="JavaScript" src="${basePath}includes/global_functions_javascript.js"></script>
+<%-- <script type="text/JavaScript" language="JavaScript" src="${basePath}includes/global_functions_javascript2.js"></script> --%>
+<script type="text/JavaScript" language="JavaScript" src="${basePath}includes/Tabs.js"></script>
+<script type="text/JavaScript" language="JavaScript" src="${basePath}includes/CalendarPopup.js"></script>
 <script type="text/JavaScript" language="JavaScript" src=
-  "includes/repetition-model/repetition-model.js"></script>
-  <script type="text/JavaScript" language="JavaScript" src="includes/prototype.js"></script>
-  <script type="text/JavaScript" language="JavaScript" src="includes/scriptaculous.js?load=effects"></script>
-  <script type="text/JavaScript" language="JavaScript" src="includes/effects.js"></script>
+  "${basePath}includes/repetition-model/repetition-model.js"></script>
+  <script type="text/JavaScript" language="JavaScript" src="${basePath}includes/prototype.js"></script>
+  <script type="text/JavaScript" language="JavaScript" src="${basePath}includes/scriptaculous.js?load=effects"></script>
+  <script type="text/JavaScript" language="JavaScript" src="${basePath}includes/effects.js"></script>
     <!-- Added for the new Calender -->
 	
-    <link rel="stylesheet" type="text/css" media="all" href="includes/new_cal/skins/aqua/theme.css" title="Aqua" />
-    <script type="text/javascript" src="includes/new_cal/calendar.js"></script>
+    <link rel="stylesheet" type="text/css" media="all" href="${basePath}includes/new_cal/skins/aqua/theme.css" title="Aqua" />
+    <script type="text/javascript" src="${basePath}includes/new_cal/calendar.js"></script>
      <!--  fix for issue 14427 Removed the mapping with wrong file name calendar_en.js-->
-      <script type="text/javascript" src="includes/new_cal/lang/calendar-en.js"></script>
-      <script type="text/javascript" src="includes/new_cal/lang/<fmt:message key="jscalendar_language_file" bundle="${resformat}"/>"></script>
-    <script type="text/javascript" src="includes/new_cal/calendar-setup.js"></script>
+      <script type="text/javascript" src="${basePath}includes/new_cal/lang/calendar-en.js"></script>
+      <script type="text/javascript" src="${basePath}includes/new_cal/lang/<fmt:message key="jscalendar_language_file" bundle="${resformat}"/>"></script>
+    <script type="text/javascript" src="${basePath}includes/new_cal/calendar-setup.js"></script>
 <!-- End -->
 
     <script language="JavaScript">
@@ -96,7 +97,7 @@ document.write('<table border="0" cellpadding="0" cellspacing="0" width="' + doc
 
 <!-- Logo -->
 
-    <div class="logo"><img src="images/Logo.gif"></div>
+    <div class="logo"><img src="${basePath}images/Logo.gif"></div>
 
 <!-- Main Navigation -->
 

--- a/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
@@ -5,6 +5,8 @@
 <fmt:setBundle basename="org.akaza.openclinica.i18n.workflow" var="resworkflow"/>
 <fmt:setBundle basename="org.akaza.openclinica.i18n.words" var="resword"/>
 <fmt:setBundle basename="org.akaza.openclinica.i18n.format" var="resformat"/>
+<jsp:useBean scope='request' id='coreResources' class='org.akaza.openclinica.dao.core.CoreResources' />
+<c:set var="basePath" value="${coreResources.getField('sysURL.basePath')}" />
 
 <script language="JavaScript">
         function reportBug() {
@@ -62,33 +64,27 @@
 <c:set var="restore" value="true"/>
 <c:if test="${tableFacadeRestore=='false'}"><c:set var="restore" value="false"/></c:if>
 <c:set var="profilePage" value="${param.profilePage}"/>
-<!--  If Controller Spring based append ../ to urls -->
-<c:set var="urlPrefix" value=""/>
-<c:set var="requestFromSpringController" value="${param.isSpringController}" />
-<c:if test="${requestFromSpringController == 'true' }">
-      <c:set var="urlPrefix" value="${pageContext.request.contextPath}/"/>
-</c:if>
 
 <!-- Main Navigation -->
      <div class="oc_nav">
         <div id="StudyInfo">
             <c:choose>
                 <c:when test='${study.parentStudyId > 0}'>
-                    <b><a href="${urlPrefix}ViewStudy?id=${study.parentStudyId}&viewFull=yes" title="<c:out value='${study.parentStudyName}'/>" alt="<c:out value='${study.parentStudyName}'/>" ><c:out value="${study.abbreviatedParentStudyName}" /></a>
-                    :&nbsp;<a href="${urlPrefix}ViewSite?id=${study.id}" title="<c:out value='${study.name}'/>" alt="<c:out value='${study.name}'/>"><c:out value="${study.abbreviatedName}" /></a></b>
+                    <b><a href="${basePath}ViewStudy?id=${study.parentStudyId}&viewFull=yes" title="<c:out value='${study.parentStudyName}'/>" alt="<c:out value='${study.parentStudyName}'/>" ><c:out value="${study.abbreviatedParentStudyName}" /></a>
+                    :&nbsp;<a href="${basePath}ViewSite?id=${study.id}" title="<c:out value='${study.name}'/>" alt="<c:out value='${study.name}'/>"><c:out value="${study.abbreviatedName}" /></a></b>
                 </c:when>
                 <c:otherwise>
-                    <b><a href="${urlPrefix}ViewStudy?id=${study.id}&viewFull=yes" title="<c:out value='${study.name}'/>" alt="<c:out value='${study.name}'/>"><c:out value="${study.abbreviatedName}" /></a></b>
+                    <b><a href="${basePath}ViewStudy?id=${study.id}&viewFull=yes" title="<c:out value='${study.name}'/>" alt="<c:out value='${study.name}'/>"><c:out value="${study.abbreviatedName}" /></a></b>
                 </c:otherwise>
             </c:choose>
             (<c:out value="${study.abbreviatedIdentifier}" />)&nbsp;&nbsp;|&nbsp;&nbsp;
-            <a href="${urlPrefix}ChangeStudy"><fmt:message key="change_study_site" bundle="${resworkflow}"/></a>
+            <a href="${basePath}ChangeStudy"><fmt:message key="change_study_site" bundle="${resworkflow}"/></a>
         </div>
         <div id="UserInfo">
-            <a href="${urlPrefix}UpdateProfile"><b><c:out value="${userBean.name}" /></b> (<c:out value="${userRole.role.description}" />)&nbsp;
+            <a href="${basePath}UpdateProfile"><b><c:out value="${userBean.name}" /></b> (<c:out value="${userRole.role.description}" />)&nbsp;
 				<c:out value="<%=ResourceBundleProvider.getLocale().toString()%>"/>
             </a>&nbsp;|&nbsp;
-            <a href="${urlPrefix}j_spring_security_logout"><fmt:message key="log_out" bundle="${resword}"/></a>
+            <a href="${basePath}j_spring_security_logout"><fmt:message key="log_out" bundle="${resword}"/></a>
         </div>
         <br/><br style="line-height: 4px;"/>
         <div class="box_T"><div class="box_L"><div class="box_R"><div class="box_B"><div class="box_TL"><div class="box_TR"><div class="box_BL"><div class="box_BR">
@@ -104,42 +100,42 @@
                                     <td>
                                         <ul>
                                         <c:if test="${userRole.coordinator || userRole.director}">
-                                            <li><a href="${urlPrefix}MainMenu"><fmt:message key="nav_home" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
-                                            <li><a href="${urlPrefix}ListStudySubjects"><fmt:message key="nav_subject_matrix" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
-                                            <li><a href="${urlPrefix}ViewNotes?module=submit"><fmt:message key="nav_notes_and_discrepancies" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
-                                            <li><a href="${urlPrefix}StudyAuditLog"><fmt:message key="nav_study_audit_log" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
+                                            <li><a href="${basePath}MainMenu"><fmt:message key="nav_home" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
+                                            <li><a href="${basePath}ListStudySubjects"><fmt:message key="nav_subject_matrix" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
+                                            <li><a href="${basePath}ViewNotes?module=submit"><fmt:message key="nav_notes_and_discrepancies" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
+                                            <li><a href="${basePath}StudyAuditLog"><fmt:message key="nav_study_audit_log" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
                                         </c:if>
                                         <c:if test="${userRole.researchAssistant ||userRole.researchAssistant2}">
-                                            <li><a href="${urlPrefix}MainMenu"><fmt:message key="nav_home" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
-                                            <li><a href="${urlPrefix}ListStudySubjects"><fmt:message key="nav_subject_matrix" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
+                                            <li><a href="${basePath}MainMenu"><fmt:message key="nav_home" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
+                                            <li><a href="${basePath}ListStudySubjects"><fmt:message key="nav_subject_matrix" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
                                             <c:if test="${study.status.available}">
-                                                <li><a href="${urlPrefix}AddNewSubject"><fmt:message key="nav_add_subject" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
+                                                <li><a href="${basePath}AddNewSubject"><fmt:message key="nav_add_subject" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
                                             </c:if>
-                                            <li><a href="${urlPrefix}ViewNotes?module=submit"><fmt:message key="nav_notes_and_discrepancies" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
+                                            <li><a href="${basePath}ViewNotes?module=submit"><fmt:message key="nav_notes_and_discrepancies" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
                                         </c:if>
                                         <c:if test="${userRole.investigator}">
-                                            <li><a href="${urlPrefix}MainMenu"><fmt:message key="nav_home" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
-                                            <li><a href="${urlPrefix}ListStudySubjects"><fmt:message key="nav_subject_matrix" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
+                                            <li><a href="${basePath}MainMenu"><fmt:message key="nav_home" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
+                                            <li><a href="${basePath}ListStudySubjects"><fmt:message key="nav_subject_matrix" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
                                             <c:if test="${study.status.available}">
-                                                <li><a href="${urlPrefix}AddNewSubject"><fmt:message key="nav_add_subject" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
+                                                <li><a href="${basePath}AddNewSubject"><fmt:message key="nav_add_subject" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
                                             </c:if>
-                                            <li><a href="${urlPrefix}ViewNotes?module=submit"><fmt:message key="nav_notes_and_discrepancies" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
+                                            <li><a href="${basePath}ViewNotes?module=submit"><fmt:message key="nav_notes_and_discrepancies" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
                                         </c:if>
                                         <c:if test="${userRole.monitor }">
-                                            <li><a href="${urlPrefix}MainMenu"><fmt:message key="nav_home" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
-                                            <li><a href="${urlPrefix}ListStudySubjects"><fmt:message key="nav_subject_matrix" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
-                                            <li><a href="${urlPrefix}pages/viewAllSubjectSDVtmp?sdv_restore=${restore}&studyId=${study.id}"><fmt:message key="nav_sdv" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
-                                            <li><a href="${urlPrefix}ViewNotes?module=submit"><fmt:message key="nav_notes_and_discrepancies" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
+                                            <li><a href="${basePath}MainMenu"><fmt:message key="nav_home" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
+                                            <li><a href="${basePath}ListStudySubjects"><fmt:message key="nav_subject_matrix" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
+                                            <li><a href="${basePath}pages/viewAllSubjectSDVtmp?sdv_restore=${restore}&studyId=${study.id}"><fmt:message key="nav_sdv" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
+                                            <li><a href="${basePath}ViewNotes?module=submit"><fmt:message key="nav_notes_and_discrepancies" bundle="${resword}"/></a>&nbsp;&nbsp;|&nbsp;&nbsp;</li>
                                         </c:if>
                                         <li id="nav_Tasks" style="position: relative; z-index: 3;">
                                             <a href="#" onmouseover="setNav('nav_Tasks');" id="nav_Tasks_link"><fmt:message key="nav_tasks" bundle="${resword}"/>
-                                                <img src="${urlPrefix}images/bt_Tasks_pulldown.gif" alt="Tasks" border="0"/></a>
+                                                <img src="${basePath}images/bt_Tasks_pulldown.gif" alt="Tasks" border="0"/></a>
                                         </li>
                                         </ul>
                                     </td>
                                     <td align="right" style="font-weight: normal;">
 
-                                        <form METHOD="GET" action="${urlPrefix}ListStudySubjects" onSubmit=" if (document.forms[0]['findSubjects_f_studySubject.label'].value == '<fmt:message key="study_subject_ID" bundle="${resword}"/>') { document.forms[0]['findSubjects_f_studySubject.label'].value=''}">
+                                        <form METHOD="GET" action="${basePath}ListStudySubjects" onSubmit=" if (document.forms[0]['findSubjects_f_studySubject.label'].value == '<fmt:message key="study_subject_ID" bundle="${resword}"/>') { document.forms[0]['findSubjects_f_studySubject.label'].value=''}">
                                             <a href="javascript:reportBug()"><fmt:message key="openclinica_report_issue" bundle="${resword}"/></a>&nbsp;|&nbsp;
                                             <a href="javascript:openDocWindow('<c:out value="${sessionScope.supportURL}" />')"><fmt:message key="openclinica_feedback" bundle="${resword}"/></a>&nbsp;&nbsp;
                                             <input type="text" name="findSubjects_f_studySubject.label" onblur="if (this.value == '') this.value = '<fmt:message key="study_subject_ID" bundle="${resword}"/>'" onfocus="if (this.value == '<fmt:message key="study_subject_ID" bundle="${resword}"/>') this.value = ''" value="<fmt:message key="study_subject_ID" bundle="${resword}"/>" class="navSearch"/>
@@ -167,106 +163,106 @@
 
 <div id="nav_hide" style="position: absolute; left: 0px; top: 0px; visibility: hidden; z-index: 2; width: 100%; height: 400px;">
 
-<a href="#" onmouseover="hideSubnavs();"><img src="${urlPrefix}images/spacer.gif" alt="" width="1000" height="400" border="0"/></a>
+<a href="#" onmouseover="hideSubnavs();"><img src="${basePath}images/spacer.gif" alt="" width="1000" height="400" border="0"/></a>
 </div>
 
 
     </div>
-    <img src="${urlPrefix}images/spacer.gif" width="596" height="1"><br>
+    <img src="${basePath}images/spacer.gif" width="596" height="1"><br>
 <!-- End Main Navigation -->
 <div id="subnav_Tasks" class="dropdown">
     <div class="dropdown_BG">
         <c:if test="${userRole.monitor }">
         <div class="taskGroup"><fmt:message key="nav_monitor_and_manage_data" bundle="${resword}"/></div>
         <div class="taskLeftColumn">
-            <div class="taskLink"><a href="${urlPrefix}ListStudySubjects"><fmt:message key="nav_subject_matrix" bundle="${resword}"/></a></div>
-            <div class="taskLink"><a href="${urlPrefix}ViewStudyEvents"><fmt:message key="nav_view_events" bundle="${resword}"/></a></div>
-            <div class="taskLink"><a href="${urlPrefix}pages/viewAllSubjectSDVtmp?sdv_restore=${restore}&studyId=${study.id}"><fmt:message key="nav_source_data_verification" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ListStudySubjects"><fmt:message key="nav_subject_matrix" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ViewStudyEvents"><fmt:message key="nav_view_events" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}pages/viewAllSubjectSDVtmp?sdv_restore=${restore}&studyId=${study.id}"><fmt:message key="nav_source_data_verification" bundle="${resword}"/></a></div>
         </div>
         <div class="taskRightColumn">
-            <div class="taskLink"><a href="${urlPrefix}ViewNotes?module=submit"><fmt:message key="nav_notes_and_discrepancies" bundle="${resword}"/></a></div>
-            <div class="taskLink"><a href="${urlPrefix}StudyAuditLog"><fmt:message key="nav_study_audit_log" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ViewNotes?module=submit"><fmt:message key="nav_notes_and_discrepancies" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}StudyAuditLog"><fmt:message key="nav_study_audit_log" bundle="${resword}"/></a></div>
         </div>
         <br clear="all">
         <div class="taskGroup"><fmt:message key="nav_extract_data" bundle="${resword}"/></div>
         <div class="taskLeftColumn">
-            <div class="taskLink"><a href="${urlPrefix}ViewDatasets"><fmt:message key="nav_view_datasets" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ViewDatasets"><fmt:message key="nav_view_datasets" bundle="${resword}"/></a></div>
         </div>
         <div class="taskRightColumn">
-            <div class="taskLink"><a href="${urlPrefix}CreateDataset"><fmt:message key="nav_create_dataset" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}CreateDataset"><fmt:message key="nav_create_dataset" bundle="${resword}"/></a></div>
         </div>
         <br clear="all">
         </c:if>
         <c:if test="${userRole.researchAssistant ||userRole.researchAssistant2  }">
         <div class="taskGroup"><fmt:message key="nav_submit_data" bundle="${resword}"/></div>
         <div class="taskLeftColumn">
-            <div class="taskLink"><a href="${urlPrefix}ListStudySubjects"><fmt:message key="nav_subject_matrix" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ListStudySubjects"><fmt:message key="nav_subject_matrix" bundle="${resword}"/></a></div>
             <c:if test="${study.status.available}">
-                <div class="taskLink"><a href="${urlPrefix}AddNewSubject"><fmt:message key="nav_add_subject" bundle="${resword}"/></a></div>
+                <div class="taskLink"><a href="${basePath}AddNewSubject"><fmt:message key="nav_add_subject" bundle="${resword}"/></a></div>
             </c:if>
-            <div class="taskLink"><a href="${urlPrefix}ViewNotes?module=submit"><fmt:message key="nav_notes_and_discrepancies" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ViewNotes?module=submit"><fmt:message key="nav_notes_and_discrepancies" bundle="${resword}"/></a></div>
         </div>
         <div class="taskRightColumn">
             <c:if test="${!study.status.frozen && !study.status.locked}">
-                <div class="taskLink"><a href="${urlPrefix}CreateNewStudyEvent"><fmt:message key="nav_schedule_event" bundle="${resword}"/></a></div>
+                <div class="taskLink"><a href="${basePath}CreateNewStudyEvent"><fmt:message key="nav_schedule_event" bundle="${resword}"/></a></div>
             </c:if>
-            <div class="taskLink"><a href="${urlPrefix}ViewStudyEvents"><fmt:message key="nav_view_events" bundle="${resword}"/></a></div>
-            <div class="taskLink"><a href="${urlPrefix}ImportCRFData"><fmt:message key="nav_import_data" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ViewStudyEvents"><fmt:message key="nav_view_events" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ImportCRFData"><fmt:message key="nav_import_data" bundle="${resword}"/></a></div>
         </div>
         <br clear="all">
         </c:if>
         <c:if test="${userRole.investigator}">
         <div class="taskGroup"><fmt:message key="nav_submit_data" bundle="${resword}"/></div>
         <div class="taskLeftColumn">
-            <div class="taskLink"><a href="${urlPrefix}ListStudySubjects"><fmt:message key="nav_subject_matrix" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ListStudySubjects"><fmt:message key="nav_subject_matrix" bundle="${resword}"/></a></div>
             <c:if test="${study.status.available}">
-                <div class="taskLink"><a href="${urlPrefix}AddNewSubject"><fmt:message key="nav_add_subject" bundle="${resword}"/></a></div>
+                <div class="taskLink"><a href="${basePath}AddNewSubject"><fmt:message key="nav_add_subject" bundle="${resword}"/></a></div>
             </c:if>
-            <div class="taskLink"><a href="${urlPrefix}ViewNotes?module=submit"><fmt:message key="nav_notes_and_discrepancies" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ViewNotes?module=submit"><fmt:message key="nav_notes_and_discrepancies" bundle="${resword}"/></a></div>
         </div>
         <div class="taskRightColumn">
             <c:if test="${!study.status.frozen && !study.status.locked}">
-                <div class="taskLink"><a href="${urlPrefix}CreateNewStudyEvent"><fmt:message key="nav_schedule_event" bundle="${resword}"/></a></div>
+                <div class="taskLink"><a href="${basePath}CreateNewStudyEvent"><fmt:message key="nav_schedule_event" bundle="${resword}"/></a></div>
             </c:if>
-            <div class="taskLink"><a href="${urlPrefix}ViewStudyEvents"><fmt:message key="nav_view_events" bundle="${resword}"/></a></div>
-            <div class="taskLink"><a href="${urlPrefix}ImportCRFData"><fmt:message key="nav_import_data" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ViewStudyEvents"><fmt:message key="nav_view_events" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ImportCRFData"><fmt:message key="nav_import_data" bundle="${resword}"/></a></div>
         </div>
         <br clear="all">
         <div class="taskGroup"><fmt:message key="nav_extract_data" bundle="${resword}"/></div>
         <div class="taskLeftColumn">
-            <div class="taskLink"><a href="${urlPrefix}ViewDatasets"><fmt:message key="nav_view_datasets" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ViewDatasets"><fmt:message key="nav_view_datasets" bundle="${resword}"/></a></div>
         </div>
         <div class="taskRightColumn">
-            <div class="taskLink"><a href="${urlPrefix}CreateDataset"><fmt:message key="nav_create_dataset" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}CreateDataset"><fmt:message key="nav_create_dataset" bundle="${resword}"/></a></div>
         </div>
         <br clear="all">
         </c:if>
         <c:if test="${userRole.coordinator || userRole.director}">
         <div class="taskGroup"><fmt:message key="nav_submit_data" bundle="${resword}"/></div>
         <div class="taskLeftColumn">
-            <div class="taskLink"><a href="${urlPrefix}ListStudySubjects"><fmt:message key="nav_subject_matrix" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ListStudySubjects"><fmt:message key="nav_subject_matrix" bundle="${resword}"/></a></div>
             <c:if test="${study.status.available}">
-                <div class="taskLink"><a href="${urlPrefix}AddNewSubject"><fmt:message key="nav_add_subject" bundle="${resword}"/></a></div>
+                <div class="taskLink"><a href="${basePath}AddNewSubject"><fmt:message key="nav_add_subject" bundle="${resword}"/></a></div>
             </c:if>
-            <div class="taskLink"><a href="${urlPrefix}ViewNotes?module=submit"><fmt:message key="nav_notes_and_discrepancies" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ViewNotes?module=submit"><fmt:message key="nav_notes_and_discrepancies" bundle="${resword}"/></a></div>
         </div>
         <div class="taskRightColumn">
             <c:if test="${!study.status.frozen && !study.status.locked}">
-                <div class="taskLink"><a href="${urlPrefix}CreateNewStudyEvent"><fmt:message key="nav_schedule_event" bundle="${resword}"/></a></div>
+                <div class="taskLink"><a href="${basePath}CreateNewStudyEvent"><fmt:message key="nav_schedule_event" bundle="${resword}"/></a></div>
             </c:if>
-            <div class="taskLink"><a href="${urlPrefix}ViewStudyEvents"><fmt:message key="nav_view_events" bundle="${resword}"/></a></div>
-            <div class="taskLink"><a href="${urlPrefix}ImportCRFData"><fmt:message key="nav_import_data" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ViewStudyEvents"><fmt:message key="nav_view_events" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ImportCRFData"><fmt:message key="nav_import_data" bundle="${resword}"/></a></div>
         </div>
         <br clear="all">
         <div class="taskGroup"><fmt:message key="nav_monitor_and_manage_data" bundle="${resword}"/></div>
         <div class="taskLeftColumn">
-            <div class="taskLink"><a href="${urlPrefix}pages/viewAllSubjectSDVtmp?sdv_restore=${restore}&studyId=${study.id}"><fmt:message key="nav_source_data_verification" bundle="${resword}"/></a></div>
-            <div class="taskLink"><a href="${urlPrefix}StudyAuditLog"><fmt:message key="nav_study_audit_log" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}pages/viewAllSubjectSDVtmp?sdv_restore=${restore}&studyId=${study.id}"><fmt:message key="nav_source_data_verification" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}StudyAuditLog"><fmt:message key="nav_study_audit_log" bundle="${resword}"/></a></div>
             <c:choose>
                 <c:when test="${study.parentStudyId > 0 && (userRole.coordinator || userRole.director) }">
                 </c:when>
                 <c:otherwise>
-                    <div class="taskLink"><a href="${urlPrefix}ViewRuleAssignment?read=true"><fmt:message key="nav_rules" bundle="${resword}"/></a></div>
+                    <div class="taskLink"><a href="${basePath}ViewRuleAssignment?read=true"><fmt:message key="nav_rules" bundle="${resword}"/></a></div>
                 </c:otherwise>
             </c:choose>
         </div>
@@ -275,40 +271,40 @@
             <c:when test="${study.parentStudyId > 0 && (userRole.coordinator || userRole.director) }">
             </c:when>
             <c:otherwise>
-                <div class="taskLink"><a href="${urlPrefix}ListSubjectGroupClass?read=true"><fmt:message key="nav_groups" bundle="${resword}"/></a></div>
-                <div class="taskLink"><a href="${urlPrefix}ListCRF?module=manage"><fmt:message key="nav_crfs" bundle="${resword}"/></a></div>
+                <div class="taskLink"><a href="${basePath}ListSubjectGroupClass?read=true"><fmt:message key="nav_groups" bundle="${resword}"/></a></div>
+                <div class="taskLink"><a href="${basePath}ListCRF?module=manage"><fmt:message key="nav_crfs" bundle="${resword}"/></a></div>
             </c:otherwise>
         </c:choose>
         </div>
         <br clear="all">
         <div class="taskGroup"><fmt:message key="nav_extract_data" bundle="${resword}"/></div>
         <div class="taskLeftColumn">
-            <div class="taskLink"><a href="${urlPrefix}ViewDatasets"><fmt:message key="nav_view_datasets" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ViewDatasets"><fmt:message key="nav_view_datasets" bundle="${resword}"/></a></div>
         </div>
         <div class="taskRightColumn">
-            <div class="taskLink"><a href="${urlPrefix}CreateDataset"><fmt:message key="nav_create_dataset" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}CreateDataset"><fmt:message key="nav_create_dataset" bundle="${resword}"/></a></div>
         </div>
         <br clear="all">
         <div class="taskGroup"><fmt:message key="nav_study_setup" bundle="${resword}"/></div>
         <div class="taskLeftColumn">
-            <div class="taskLink"><a href="${urlPrefix}ViewStudy?id=${study.id}&viewFull=yes"><fmt:message key="nav_view_study" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ViewStudy?id=${study.id}&viewFull=yes"><fmt:message key="nav_view_study" bundle="${resword}"/></a></div>
             <c:choose>
                 <c:when test="${study.parentStudyId > 0 && (userRole.coordinator || userRole.director) }">
                 </c:when>
                 <c:otherwise>
-                    <div class="taskLink"><a href="${urlPrefix}pages/studymodule"><fmt:message key="nav_build_study" bundle="${resword}"/></a></div>
-                    <!-- <div class="taskLink"><a href="${urlPrefix}ListEventDefinition?read=true"><fmt:message key="nav_event_definitions" bundle="${resword}"/></a></div>  -->
+                    <div class="taskLink"><a href="${basePath}pages/studymodule"><fmt:message key="nav_build_study" bundle="${resword}"/></a></div>
+                    <!-- <div class="taskLink"><a href="${basePath}ListEventDefinition?read=true"><fmt:message key="nav_event_definitions" bundle="${resword}"/></a></div>  -->
                 </c:otherwise>
             </c:choose>
         </div>
         <div class="taskRightColumn">
-            <div class="taskLink"><a href="${urlPrefix}ListStudyUser"><fmt:message key="nav_users" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ListStudyUser"><fmt:message key="nav_users" bundle="${resword}"/></a></div>
             <%--
             <c:choose>
                 <c:when test="${study.parentStudyId > 0 && (userRole.coordinator || userRole.director) }">
                 </c:when>
                 <c:otherwise>
-                    <div class="taskLink"><a href="${urlPrefix}ListSite?read=true"><fmt:message key="nav_sites" bundle="${resword}"/></a></div>
+                    <div class="taskLink"><a href="${basePath}ListSite?read=true"><fmt:message key="nav_sites" bundle="${resword}"/></a></div>
                 </c:otherwise>
             </c:choose>
              --%>
@@ -318,22 +314,22 @@
         <c:if test="${userBean.sysAdmin || userBean.techAdmin}">
         <div class="taskGroup"><fmt:message key="nav_administration" bundle="${resword}"/></div>
         <div class="taskLeftColumn">
-            <div class="taskLink"><a href="${urlPrefix}ListStudy"><fmt:message key="nav_studies" bundle="${resword}"/></a></div>
-            <div class="taskLink"><a href="${urlPrefix}ListUserAccounts"><fmt:message key="nav_users" bundle="${resword}"/></a></div>
-            <div class="taskLink"><a href="${urlPrefix}ListCRF?module=admin"><fmt:message key="nav_crfs" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ListStudy"><fmt:message key="nav_studies" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ListUserAccounts"><fmt:message key="nav_users" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ListCRF?module=admin"><fmt:message key="nav_crfs" bundle="${resword}"/></a></div>
         </div>
         <div class="taskRightColumn">
-            <div class="taskLink"><a href="${urlPrefix}ViewAllJobs"><fmt:message key="nav_jobs" bundle="${resword}"/></a></div>
-            <div class="taskLink"><a href="${urlPrefix}ListSubject"><fmt:message key="nav_subjects" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ViewAllJobs"><fmt:message key="nav_jobs" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}ListSubject"><fmt:message key="nav_subjects" bundle="${resword}"/></a></div>
         </div>
         <br clear="all">
         </c:if>
         <div class="taskGroup"><fmt:message key="nav_other" bundle="${resword}"/></div>
         <div class="taskLeftColumn">
-            <div class="taskLink"><a href="${urlPrefix}UpdateProfile"><fmt:message key="nav_update_profile" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}UpdateProfile"><fmt:message key="nav_update_profile" bundle="${resword}"/></a></div>
         </div>
         <div class="taskRightColumn">
-            <div class="taskLink"><a href="${urlPrefix}j_spring_security_logout"><fmt:message key="nav_log_out" bundle="${resword}"/></a></div>
+            <div class="taskLink"><a href="${basePath}j_spring_security_logout"><fmt:message key="nav_log_out" bundle="${resword}"/></a></div>
         </div>
         <br clear="all">
         <div></div>

--- a/web/src/main/webapp/WEB-INF/jsp/include/sideAlert.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/sideAlert.jsp
@@ -4,6 +4,8 @@
 
 
 <fmt:setBundle basename="org.akaza.openclinica.i18n.words" var="resword"/>
+<jsp:useBean scope='request' id='coreResources' class='org.akaza.openclinica.dao.core.CoreResources' />
+<c:set var="basePath" value="${coreResources.getField('sysURL.basePath')}" />
 
 <table border="0" cellpadding="0" cellspacing="0" <%--style="position: relative; top: -21px;"--%>>
  
@@ -23,7 +25,7 @@
 	<tr id="sidebar_Alerts_open" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Alerts_open'); leftnavExpand('sidebar_Alerts_closed');"><img src="${pageContext.request.contextPath}/images/sidebar_collapse.gif" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Alerts_open'); leftnavExpand('sidebar_Alerts_closed');"><img src="${basePath}images/sidebar_collapse.gif" border="0" align="right" hspace="10"></a>
 
 		<b><fmt:message key="alerts_messages" bundle="${resword}"/></b>
 
@@ -35,7 +37,7 @@
             <jsp:include page="../include/showSideMessage.jsp" />
             </c:when>
             <c:otherwise>             
-            <fmt:message key="have_logged_out_application" bundle="${resword}"/><a href="MainMenu"><fmt:message key="login_page" bundle="${resword}"/></a> <fmt:message key="in_order_to_re_enter_openclinica" bundle="${resword}"/>         
+            <fmt:message key="have_logged_out_application" bundle="${resword}"/><a href="${basePath}MainMenu"><fmt:message key="login_page" bundle="${resword}"/></a> <fmt:message key="in_order_to_re_enter_openclinica" bundle="${resword}"/>
 		
             </c:otherwise>
             </c:choose>
@@ -52,7 +54,7 @@
 	<tr id="sidebar_Alerts_closed" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Alerts_open'); leftnavExpand('sidebar_Alerts_closed');"><img src="${pageContext.request.contextPath}/images/sidebar_expand.gif" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Alerts_open'); leftnavExpand('sidebar_Alerts_closed');"><img src="${basePath}images/sidebar_expand.gif" border="0" align="right" hspace="10"></a>
 
 		<b><fmt:message key="alerts_messages" bundle="${resword}"/></b>
 
@@ -63,7 +65,7 @@
        <tr id="sidebar_Alerts_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Alerts_open'); leftnavExpand('sidebar_Alerts_closed');"><img src="${pageContext.request.contextPath}/images/sidebar_collapse.gif" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Alerts_open'); leftnavExpand('sidebar_Alerts_closed');"><img src="${basePath}images/sidebar_collapse.gif" border="0" align="right" hspace="10"></a>
 
 		<b><fmt:message key="alerts_messages" bundle="${resword}"/></b>
 
@@ -75,7 +77,7 @@
             <jsp:include page="../include/showSideMessage.jsp" />
             </c:when>
             <c:otherwise>             
-            <fmt:message key="have_logged_out_application" bundle="${resword}"/><a href="MainMenu"><fmt:message key="login_page" bundle="${resword}"/></a> <fmt:message key="in_order_to_re_enter_openclinica" bundle="${resword}"/>          
+            <fmt:message key="have_logged_out_application" bundle="${resword}"/><a href="${basePath}MainMenu"><fmt:message key="login_page" bundle="${resword}"/></a> <fmt:message key="in_order_to_re_enter_openclinica" bundle="${resword}"/>
 		
             </c:otherwise>
             </c:choose>
@@ -88,7 +90,7 @@
 	<tr id="sidebar_Alerts_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Alerts_open'); leftnavExpand('sidebar_Alerts_closed');"><img src="${pageContext.request.contextPath}/images/sidebar_expand.gif" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Alerts_open'); leftnavExpand('sidebar_Alerts_closed');"><img src="${basePath}images/sidebar_expand.gif" border="0" align="right" hspace="10"></a>
 
 		<b><fmt:message key="alerts_messages" bundle="${resword}"/></b>
 

--- a/web/src/main/webapp/WEB-INF/jsp/include/sideIconsSubject.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/sideIconsSubject.jsp
@@ -3,6 +3,8 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 <fmt:setBundle basename="org.akaza.openclinica.i18n.words" var="reswords"/>
+<jsp:useBean scope='request' id='coreResources' class='org.akaza.openclinica.dao.core.CoreResources' />
+<c:set var="basePath" value="${coreResources.getField('sysURL.basePath')}" />
 <%--
 View
   Edit
@@ -14,7 +16,7 @@ View
 <tr id="sidebar_IconKey_open">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_IconKey_open'); leftnavExpand('sidebar_IconKey_closed');"><img src="images/sidebar_collapse.gif" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_IconKey_open'); leftnavExpand('sidebar_IconKey_closed');"><img src="${basePath}images/sidebar_collapse.gif" border="0" align="right" hspace="10"></a>
 
         <b><fmt:message key="icon_key" bundle="${reswords}"/></b><br clear="all"><br>
 
@@ -23,67 +25,67 @@ View
                 <td><strong><u><fmt:message key="statuses" bundle="${reswords}"/></u></strong></td>
             </tr>
             <tr>
-                <td>&nbsp;<img src="images/icon_NotStarted.gif"></td>
+                <td>&nbsp;<img src="${basePath}images/icon_NotStarted.gif"></td>
                 <td><fmt:message key="not_started" bundle="${reswords}"/></td>
             </tr>
             <tr>
-                <td>&nbsp;<img src="images/icon_Scheduled.gif"></td>
+                <td>&nbsp;<img src="${basePath}images/icon_Scheduled.gif"></td>
                 <td><fmt:message key="scheduled" bundle="${reswords}"/></td>
             </tr>
             <tr>
-                <td>&nbsp;<img src="images/icon_InitialDE.gif"></td>
+                <td>&nbsp;<img src="${basePath}images/icon_InitialDE.gif"></td>
                 <td><fmt:message key="data_entry_started" bundle="${reswords}"/></td>
             </tr>
             <tr>
-                <td>&nbsp;<img src="images/icon_Stopped.gif"></td>
+                <td>&nbsp;<img src="${basePath}images/icon_Stopped.gif"></td>
                 <td><fmt:message key="stopped" bundle="${reswords}"/></td>
             </tr>
             <tr>
-                <td>&nbsp;<img src="images/icon_Skipped.gif"></td>
+                <td>&nbsp;<img src="${basePath}images/icon_Skipped.gif"></td>
                 <td><fmt:message key="skipped" bundle="${reswords}"/></td>
             </tr>
             <tr>
-                <td>&nbsp;<img src="images/icon_DEcomplete.gif"></td>
+                <td>&nbsp;<img src="${basePath}images/icon_DEcomplete.gif"></td>
                 <td><fmt:message key="completed" bundle="${reswords}"/></td>
             </tr>
             <tr>
-                <td>&nbsp;<img src="images/icon_Signed.gif"></td>
+                <td>&nbsp;<img src="${basePath}images/icon_Signed.gif"></td>
                 <td><fmt:message key="signed" bundle="${reswords}"/></td>
             </tr>
             <tr>
-                <td>&nbsp;<img src="images/icon_Locked.gif"></td>
+                <td>&nbsp;<img src="${basePath}images/icon_Locked.gif"></td>
                 <td><fmt:message key="locked" bundle="${reswords}"/></td>
             </tr>
             <tr>
-                <td>&nbsp;<img src="images/icon_Invalid.gif"></td>
+                <td>&nbsp;<img src="${basePath}images/icon_Invalid.gif"></td>
                 <td><fmt:message key="invalid" bundle="${reswords}"/></td>
             </tr>
             <tr>
                 <td><strong><u><fmt:message key="actions" bundle="${reswords}"/></u></strong></td>
             </tr>
             <tr>
-                <td>&nbsp;<img src="images/bt_View.gif"></td>
+                <td>&nbsp;<img src="${basePath}images/bt_View.gif"></td>
                 <td><fmt:message key="view" bundle="${reswords}"/></td>
             </tr>
             <tr>
-                <td>&nbsp;<img src="images/bt_Edit.gif"></td>
+                <td>&nbsp;<img src="${basePath}images/bt_Edit.gif"></td>
                 <td><fmt:message key="edit" bundle="${reswords}"/></td>
             </tr>
             <c:if test="${userRole.manageStudy}">
                 <tr>
-                    <td>&nbsp;<img src="images/bt_Remove.gif"></td>
+                    <td>&nbsp;<img src="${basePath}images/bt_Remove.gif"></td>
                     <td><fmt:message key="remove" bundle="${reswords}"/></td>
                 </tr>
                 <tr>
-                    <td>&nbsp;<img src="images/bt_Restore.gif"></td>
+                    <td>&nbsp;<img src="${basePath}images/bt_Restore.gif"></td>
                     <td><fmt:message key="restore" bundle="${reswords}"/></td>
                 </tr>
                 <tr>
-                    <td>&nbsp;<img src="images/bt_Reassign.gif"></td>
+                    <td>&nbsp;<img src="${basePath}images/bt_Reassign.gif"></td>
                     <td><fmt:message key="reassign" bundle="${reswords}"/></td>
                 </tr>
                 <tr>
-                    <td>&nbsp;<img src="images/icon_Signed.gif"></td>
+                    <td>&nbsp;<img src="${basePath}images/icon_Signed.gif"></td>
                     <td><fmt:message key="sign" bundle="${reswords}"/></td>
                 </tr>
             </c:if>
@@ -101,7 +103,7 @@ View
 <tr id="sidebar_IconKey_closed" style="display: none">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_IconKey_open'); leftnavExpand('sidebar_IconKey_closed');"><img src="images/sidebar_expand.gif" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_IconKey_open'); leftnavExpand('sidebar_IconKey_closed');"><img src="${basePath}images/sidebar_expand.gif" border="0" align="right" hspace="10"></a>
 
         <b><fmt:message key="icon_key" bundle="${reswords}"/></b>
 

--- a/web/src/main/webapp/WEB-INF/jsp/include/sideInfo.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/sideInfo.jsp
@@ -4,7 +4,8 @@
 
 <fmt:setBundle basename="org.akaza.openclinica.i18n.words" var="resword"/>  
 <fmt:setBundle basename="org.akaza.openclinica.i18n.notes" var="restext"/> 
-
+<jsp:useBean scope='request' id='coreResources' class='org.akaza.openclinica.dao.core.CoreResources' />
+<c:set var="basePath" value="${coreResources.getField('sysURL.basePath')}" />
 
 <%--<jsp:useBean scope="session" id="panel" class="org.akaza.openclinica.view.StudyInfoPanel" />--%>
 
@@ -20,7 +21,7 @@
 
 		<a href="javascript:leftnavExpand('sidebar_Info_open'); leftnavExpand('sidebar_Info_closed');">
 
-                <img src="${pageContext.request.contextPath}/images/sidebar_collapse.gif" border="0" align="right" hspace="10">
+                <img src="${basePath}images/sidebar_collapse.gif" border="0" align="right" hspace="10">
 </a>
 
 		<b><fmt:message key="info" bundle="${restext}"/></b>
@@ -79,7 +80,7 @@
     <tr id="sidebar_Info_closed"<c:if test="${! closeInfoShowIcons}">style="display: none"</c:if>>
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Info_open'); leftnavExpand('sidebar_Info_closed');"><img src="${pageContext.request.contextPath}/images/sidebar_expand.gif" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Info_open'); leftnavExpand('sidebar_Info_closed');"><img src="${basePath}images/sidebar_expand.gif" border="0" align="right" hspace="10"></a>
 
 		<b>Info</b>
 
@@ -129,10 +130,10 @@
 			  <c:set var="eventCount" value="${eventCount+1}"/>
 			  <tr>
 	           <td valign="top" width="10" class="leftmenu"><a href="javascript:leftnavExpand('leftnavSubRow_SubSection<c:out value="${eventCount}"/>'); 
-		          javascript:setImage('ExpandGroup<c:out value="${eventCount}"/>','${pageContext.request.contextPath}/images/bt_Collapse.gif');"><img
-		          name="ExpandGroup<c:out value="${eventCount}"/>" src="${pageContext.request.contextPath}/images/bt_Expand.gif" border="0"></a></td>
+		          javascript:setImage('ExpandGroup<c:out value="${eventCount}"/>','<c:out value="${basePath}" />images/bt_Collapse.gif');"><img
+		          name="ExpandGroup<c:out value="${eventCount}"/>" src="${basePath}images/bt_Expand.gif" border="0"></a></td>
 	              <td valign="top" class="leftmenu"><a href="javascript:leftnavExpand('leftnavSubRow_SubSection<c:out value="${eventCount}"/>'); 
-		            javascript:setImage('ExpandGroup<c:out value="${eventCount}"/>','${pageContext.request.contextPath}/images/bt_Collapse.gif');"><b><c:out value="${line.info}" escapeXml="false"/></b></a>
+		            javascript:setImage('ExpandGroup<c:out value="${eventCount}"/>','<c:out value="${basePath}" />images/bt_Collapse.gif');"><b><c:out value="${line.info}" escapeXml="false"/></b></a>
 		       </td>
              </tr>  
              </c:when>
@@ -160,7 +161,7 @@
 		             <td valign="top" class="vline">
 		          </c:otherwise> 
 		         </c:choose>
-		         <img src="images/leftbar_hline.gif"></td>
+		         <img src="${basePath}images/leftbar_hline.gif"></td>
 		         <td valign="top" class="leftmenu" style="font-size:11px; color:#789EC5"><c:out value="${line.info}" escapeXml="false"/></td>
 	           </tr>
              </c:if>
@@ -184,18 +185,18 @@
 </c:when>
 <c:otherwise>
     <br><br>
-	<a href="MainMenu"><fmt:message key="login" bundle="${resword}"/></a>	
+	<a href="${basePath}MainMenu"><fmt:message key="login" bundle="${resword}"/></a>
 	<br><br>
-	<a href="RequestAccount"><fmt:message key="request_an_account" bundle="${resword}"/></a>
+	<a href="${basePath}RequestAccount"><fmt:message key="request_an_account" bundle="${resword}"/></a>
 	<br><br>
-	<a href="RequestPassword"><fmt:message key="forgot_password" bundle="${resword}"/></a>
+	<a href="${basePath}RequestPassword"><fmt:message key="forgot_password" bundle="${resword}"/></a>
 </c:otherwise>
 </c:choose>
 
 
 <!-- End Sidebar Contents -->
 
-				<br><img src="images/spacer.gif" width="120" height="1">
+				<br><img src="${basePath}images/spacer.gif" width="120" height="1">
 
 				</td>
 				<td class="aka_revised_content" valign="top">

--- a/web/src/main/webapp/WEB-INF/jsp/include/studySideInfo.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/studySideInfo.jsp
@@ -5,28 +5,29 @@
 <fmt:setBundle basename="org.akaza.openclinica.i18n.words" var="resword"/>
 <fmt:setBundle basename="org.akaza.openclinica.i18n.format" var="resformat"/>
 <c:set var="dteFormat"><fmt:message key="date_format_string" bundle="${resformat}"/></c:set>
+<jsp:useBean scope='request' id='coreResources' class='org.akaza.openclinica.dao.core.CoreResources' />
+<c:set var="basePath" value="${coreResources.getField('sysURL.basePath')}" />
 
 <c:choose>
     <c:when test="${study.status.name != 'removed' && study.status.name != 'auto-removed'}">
-    <c:url var="viewStudy" value="/ViewStudy"/>
     <c:choose>
     <c:when test="${study.parentStudyId>0}">
     <b><fmt:message key="study" bundle="${resword}"/>:</b>&nbsp;
-     <a href="${viewStudy}?id=<c:out value="${study.parentStudyId}"/>&viewFull=yes"><c:out value="${study.parentStudyName}"/></a>
+     <a href="${basePath}ViewStudy?id=${study.parentStudyId}&viewFull=yes"><c:out value="${study.parentStudyName}"/></a>
      <br><br>
     <b>Site:</b>&nbsp;
-     <a href="${viewStudy}?id=<c:out value="${study.id}"/>">
+     <a href="${basePath}ViewStudy?id=${study.id}">
     </c:when>
     <c:otherwise>
     <b><fmt:message key="study" bundle="${resword}"/>:</b>&nbsp;
-     <a href="${viewStudy}?id=<c:out value="${study.id}"/>&viewFull=yes">
+     <a href="${basePath}ViewStudy?id=${study.id}&viewFull=yes">
     </c:otherwise>
     </c:choose>
     <c:out value="${study.name}"/></a>
 
     <br><br>    
     <c:if test="${studySubject != null}">
-    <b><a href="ViewStudySubject?id=<c:out value="${studySubject.id}"/>"><fmt:message key="study_subject_ID" bundle="${resword}"/></a>:</b>&nbsp; <c:out value="${studySubject.label}"/>
+    <b><a href="${basePath}ViewStudySubject?id=${studySubject.id}"><fmt:message key="study_subject_ID" bundle="${resword}"/></a>:</b>&nbsp; <c:out value="${studySubject.label}"/>
 
     <br><br>
     </c:if>

--- a/web/src/main/webapp/WEB-INF/jsp/include/submitDataSide.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/submitDataSide.jsp
@@ -1,6 +1,10 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+
+<jsp:useBean scope='request' id='coreResources' class='org.akaza.openclinica.dao.core.CoreResources' />
+<c:set var="basePath" value="${coreResources.getField('sysURL.basePath')}" />
+
   <c:choose>	   
 		<c:when test="${panel.orderedData}">
 		 <c:set var="count" value="0"/>
@@ -25,13 +29,13 @@
 			  <c:set var="eventCount" value="${eventCount+1}"/>
 			  <tr>
 	           <td valign="top" width="10" class="leftmenu"><a href="javascript:leftnavExpand('leftnavSubRow_SubSection<c:out value="${eventCount}"/>'); 
-		          javascript:setImage('ExpandGroup<c:out value="${eventCount}"/>','images/bt_Collapse.gif');"><img 
-		          name="ExpandGroup<c:out value="${eventCount}"/>" src="images/bt_Expand.gif" border="0"></a></td>
+		          javascript:setImage('ExpandGroup<c:out value="${eventCount}"/>','<c:out value="${basePath}" />images/bt_Collapse.gif');"><img
+		          name="ExpandGroup<c:out value="${eventCount}"/>" src="${basePath}images/bt_Expand.gif" border="0"></a></td>
 	            
 	            <c:choose>
                  <c:when test="${!line.current}">
 	              <td valign="top" class="leftmenu"><a href="javascript:leftnavExpand('leftnavSubRow_SubSection<c:out value="${eventCount}"/>'); 
-		            javascript:setImage('ExpandGroup<c:out value="${eventCount}"/>','images/bt_Collapse.gif');"><b><c:out value="${line.info}" escapeXml="false"/></b></a>
+		            javascript:setImage('ExpandGroup<c:out value="${eventCount}"/>','<c:out value="${basePath}" />images/bt_Collapse.gif');"><b><c:out value="${line.info}" escapeXml="false"/></b></a>
 		          </td>
 		         </c:when>
 		         <c:otherwise>
@@ -75,7 +79,7 @@
 		             <td valign="top" class="vline">
 		          </c:otherwise> 
 		         </c:choose>
-		         <img src="images/leftbar_hline.gif"></td>
+		         <img src="${basePath}images/leftbar_hline.gif"></td>
 		         <c:choose>
                	 <c:when test="${studySubject.status.name != 'removed' && studySubject.status.name != 'auto-removed'}">
 		         	<td valign="top" class="leftmenu"><c:out value="${line.title}" escapeXml="false"/>&nbsp;<c:out value="${line.info}" escapeXml="false"/></td>
@@ -83,7 +87,7 @@
 	           	 <c:otherwise>
                		<c:choose>
                		<c:when test="${first == 0}">  
-		         		<td valign="top" class="leftmenu"><c:out value="<img src='images/icon_Invalid.gif' alt='Invalid'>" escapeXml="false"/>&nbsp;<c:out value="${line.info}" escapeXml="false"/></td>
+		         		<td valign="top" class="leftmenu"><img src="${basePath}images/icon_Invalid.gif" alt="Invalid">&nbsp;<c:out value="${line.info}" escapeXml="false"/></td>
 	           	 	</c:when>
 	           	 	<c:otherwise>
               			<c:set var="first" value="0"/>

--- a/web/src/main/webapp/WEB-INF/jsp/menu.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/menu.jsp
@@ -9,19 +9,21 @@
 <jsp:useBean scope='session' id='userBean' class='org.akaza.openclinica.bean.login.UserAccountBean'/>
 <jsp:useBean scope='session' id='study' class='org.akaza.openclinica.bean.managestudy.StudyBean' />
 <jsp:useBean scope='session' id='userRole' class='org.akaza.openclinica.bean.login.StudyUserRoleBean' />
+<jsp:useBean scope='request' id='coreResources' class='org.akaza.openclinica.dao.core.CoreResources' />
+<c:set var="basePath" value="${coreResources.getField('sysURL.basePath')}" />
 
 <jsp:include page="include/home-header.jsp"/>
 <!-- move the alert message to the sidebar-->
 <jsp:include page="include/sideAlert.jsp"/>
 
 
-<link rel="stylesheet" href="includes/jmesa/jmesa.css" type="text/css">
-<script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jquery.min.js"></script>
-<script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jquery.jmesa.js"></script>
-<script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jmesa.js"></script>
-<%-- <script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jmesa-original.js"></script> --%>
-<script type="text/javascript" language="JavaScript" src="includes/jmesa/jquery.blockUI.js"></script>
-  <script type="text/javascript" language="JavaScript" src="includes/jmesa/jquery-migrate-1.1.1.js"></script>
+<link rel="stylesheet" href="${basePath}includes/jmesa/jmesa.css" type="text/css">
+<script type="text/JavaScript" language="JavaScript" src="${basePath}includes/jmesa/jquery.min.js"></script>
+<script type="text/JavaScript" language="JavaScript" src="${basePath}includes/jmesa/jquery.jmesa.js"></script>
+<script type="text/JavaScript" language="JavaScript" src="${basePath}includes/jmesa/jmesa.js"></script>
+<%-- <script type="text/JavaScript" language="JavaScript" src="${basePath}includes/jmesa/jmesa-original.js"></script> --%>
+<script type="text/javascript" language="JavaScript" src="${basePath}includes/jmesa/jquery.blockUI.js"></script>
+<script type="text/javascript" language="JavaScript" src="${basePath}includes/jmesa/jquery-migrate-1.1.1.js"></script>
 <style type="text/css">
 
         .graph {
@@ -55,7 +57,9 @@
 <tr id="sidebar_Instructions_open" style="display: all">
         <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><img src="images/sidebar_collapse.gif" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');">
+          <img src="${basePath}images/sidebar_collapse.gif" border="0" align="right" hspace="10">
+        </a>
 
         <b><fmt:message key="instructions" bundle="${resword}"/></b>
 
@@ -69,7 +73,8 @@
     <tr id="sidebar_Instructions_closed" style="display: none">
         <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><img src="images/sidebar_expand.gif" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');">
+          <img src="${basePath}images/sidebar_expand.gif" border="0" align="right" hspace="10"></a>
 
         <b><fmt:message key="instructions" bundle="${resword}"/></b>
 
@@ -91,7 +96,8 @@
                 </c:otherwise>
         </c:choose>
         <a href="javascript:openDocWindow('https://docs.openclinica.com/3.1/openclinica-user-guide/overview-openclinica')">
-            <img src="images/bt_Help_Manage.gif" border="0" alt="<fmt:message key="help" bundle="${resword}"/>" title="<fmt:message key="help" bundle="${resword}"/>"></a>
+          <img src="${basePath}images/bt_Help_Manage.gif" border="0" alt="<fmt:message key="help" bundle="${resword}"/>" title="<fmt:message key="help" bundle="${resword}"/>">
+        </a>
     </span>
 </h1>
 
@@ -119,7 +125,7 @@
 
 </c:if>
 <span class="table_title_Admin" style="line-height:15px;">
-<a href="ViewNotes?module=submit&listNotes_f_discrepancyNoteBean.user=<c:out value='${userBean.name}' />"><fmt:message key="notes_assigned_to_me" bundle="${restext}"/><span>${assignedDiscrepancies}</span>&nbsp;</a><br /><br />
+  <a href="${basePath}ViewNotes?module=submit&listNotes_f_discrepancyNoteBean.user=${userBean.name}"><fmt:message key="notes_assigned_to_me" bundle="${restext}"/><span>${assignedDiscrepancies}</span>&nbsp;</a><br /><br />
 </span>
 
 <c:if test="${userRole.investigator || userRole.researchAssistant || userRole.researchAssistant2}">
@@ -134,7 +140,7 @@
     }
     function onInvokeExportAction(id) {
         var parameterString = createParameterStringForLimit(id);
-        location.href = '${pageContext.request.contextPath}/MainMenu?'+ parameterString;
+        location.href = '<c:out value="${basePath}MainMenu" />?'+ parameterString;
     }
     jQuery(document).ready(function() {
         jQuery('#addSubject').click(function() {
@@ -147,7 +153,7 @@
         });
     });
     </script>
-    <form  action="${pageContext.request.contextPath}/ListStudySubjects">
+    <form  action="${basePath}ListStudySubjects">
         <input type="hidden" name="module" value="admin">
         ${findSubjectsHtml}
     </form>
@@ -181,12 +187,12 @@
 <table>
 <tr>
     <td valign="top">
-    <form  action="${pageContext.request.contextPath}/MainMenu">
+    <form  action="${basePath}MainMenu">
         ${studySiteStatistics}
     </form>
     </td>
     <td valign="top">
-    <form  action="${pageContext.request.contextPath}/MainMenu">
+    <form  action="${basePath}MainMenu" />">
         ${studyStatistics}
     </form>
     </td>
@@ -197,13 +203,13 @@
 <table>
 <tr>
     <td valign="top">
-    <form  action="${pageContext.request.contextPath}/MainMenu">
+    <form  action="${basePath}MainMenu">
         ${subjectEventStatusStatistics}
     </form>
     </td>
 
     <td valign="top">
-    <form  action="${pageContext.request.contextPath}/MainMenu">
+    <form  action="${basePath}MainMenu">
         ${studySubjectStatusStatistics}
     </form>
     </td>
@@ -227,7 +233,7 @@
         var bool = confirm(
                 "<fmt:message key="uncheck_sdv" bundle="${resmessages}"/>");
         if(bool){
-            formObj.action='${pageContext.request.contextPath}/pages/handleSDVRemove';
+            formObj.action='<c:out value="${basePath}pages/handleSDVRemove" />';
             formObj.crfId.value=crfId;
             formObj.submit();
         }
@@ -237,15 +243,25 @@
 <div id="searchFilterSDV">
     <table border="0" cellpadding="0" cellspacing="0">
         <tr>
-            <td valign="bottom" id="Tab1'">
+            <td valign="bottom" id="Tab1">
                 <div id="Tab1NotSelected"><div class="tab_BG"><div class="tab_L"><div class="tab_R">
-                    <a class="tabtext" title="<fmt:message key="view_by_event_CRF" bundle="${resword}"/>" href='pages/viewAllSubjectSDVtmp?studyId=${studyId}' onclick="javascript:HighlightTab(1);"><fmt:message key="view_by_event_CRF" bundle="${resword}"/></a></div></div></div></div>
-                <div id="Tab1Selected" style="display:none"><div class="tab_BG_h"><div class="tab_L_h"><div class="tab_R_h"><span class="tabtext"><fmt:message key="view_by_event_CRF" bundle="${resword}"/></span></div></div></div></div></td>
+                  <a href="${basePath}pages/viewAllSubjectSDVtmp?studyId=${studyId}" />" class="tabtext" title="<fmt:message key="view_by_event_CRF" bundle="${resword}"/>" onclick="javascript:HighlightTab(1);">
+                    <fmt:message key="view_by_event_CRF" bundle="${resword}"/>
+                  </a>
+                </div></div></div></div>
+                <div id="Tab1Selected" style="display:none"><div class="tab_BG_h"><div class="tab_L_h"><div class="tab_R_h">
+                  <span class="tabtext"><fmt:message key="view_by_event_CRF" bundle="${resword}"/></span>
+                </div></div></div></div></td>
               
             <td valign="bottom" id="Tab2'">
                 <div id="Tab2Selected"><div class="tab_BG"><div class="tab_L"><div class="tab_R">
-                    <a class="tabtext" title="<fmt:message key="view_by_studysubjectID" bundle="${resword}"/>" href='pages/viewSubjectAggregate?studyId=${studyId}' onclick="javascript:HighlightTab(2);"><fmt:message key="view_by_studysubjectID" bundle="${resword}"/></a></div></div></div></div>
-                <div id="Tab2NotSelected" style="display:none"><div class="tab_BG_h"><div class="tab_L_h"><div class="tab_R_h"><span class="tabtext"><fmt:message key="view_by_studysubjectID" bundle="${resword}"/></span></div></div></div></div></td>
+                  <a href="${basePath}pages/viewSubjectAggregate?studyId=${studyId}" class="tabtext" title="<fmt:message key="view_by_studysubjectID" bundle="${resword}"/>" onclick="javascript:HighlightTab(2);">
+                    <fmt:message key="view_by_studysubjectID" bundle="${resword}"/>
+                  </a>
+                </div></div></div></div>
+                <div id="Tab2NotSelected" style="display:none"><div class="tab_BG_h"><div class="tab_L_h"><div class="tab_R_h">
+                  <span class="tabtext"><fmt:message key="view_by_studysubjectID" bundle="${resword}"/></span>
+                </div></div></div></div></td>
 
         </tr>
     </table>
@@ -254,7 +270,7 @@
     </script>
 </div>
 <div id="subjectSDV">
-    <form name='sdvForm' action="${pageContext.request.contextPath}/pages/viewAllSubjectSDVtmp">
+    <form name='sdvForm' action="${basePath}pages/viewAllSubjectSDVtmp" />">
         <input type="hidden" name="studyId" value="${study.id}">
         <input type="hidden" name=imagePathPrefix value="">
         <%--This value will be set by an onclick handler associated with an SDV button --%>
@@ -264,8 +280,8 @@
         <%--<input type="hidden" name="decorator" value="mydecorator">--%>
         ${sdvMatrix}
         <br />
-        <input type="submit" name="sdvAllFormSubmit" class="button_medium" value="<fmt:message key="submit" bundle="${resword}"/>" onclick="this.form.method='POST';this.form.action='${pageContext.request.contextPath}/pages/handleSDVPost';this.form.submit();"/>
-        <input type="submit" name="sdvAllFormCancel" class="button_medium" value="<fmt:message key="cancel" bundle="${resword}"/>" onclick="this.form.action='${pageContext.request.contextPath}/pages/viewAllSubjectSDVtmp';this.form.submit();"/>
+        <input type="submit" name="sdvAllFormSubmit" class="button_medium" value="<fmt:message key="submit" bundle="${resword}"/>" onclick="this.form.method='POST';this.form.action='<c:out value="${basePath}pages/handleSDVPost" />';this.form.submit();"/>
+        <input type="submit" name="sdvAllFormCancel" class="button_medium" value="<fmt:message key="cancel" bundle="${resword}"/>" onclick="this.form.action='<c:out value="${basePath}pages/viewAllSubjectSDVtmp" />';this.form.submit();"/>
     </form>
 
 </div>


### PR DESCRIPTION
MainMenu incorrectly uses full URI for stylesheet may interfere with
some reverse proxy setups.

Instead of using ContextPath better if we use path from sysURL in
datainfo.properties.

We have no idea of how the reverse proxy was set, one thing we know is
that variable sysURL that the sysadmin set to match the reverse proxy
configuration.

Helps with consistency, for example to avoid similar use of urlPrefix
(which value either empty or '../' depending on circumstances) in
navBar.jsp.