### PR TITLE
Fix for OC-6061 CRF locked error message

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/web/filter/OpenClinicaSecurityContextLogoutHandler.java
+++ b/web/src/main/java/org/akaza/openclinica/web/filter/OpenClinicaSecurityContextLogoutHandler.java
@@ -17,7 +17,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 
 /**
- * Call Super Class SecurityContextLogoutHandler that Performs a logout by modifying the {@link org.springframework.security.context.SecurityContextHolder}.
+ * Call Super Class SecurityContextLogoutHandler that Performs a logout by modifying the {@see org.springframework.security.context.SecurityContextHolder}.
  * <p>
  * Will log this event to an OpenClinica user logging table
  * 

--- a/web/src/main/java/org/akaza/openclinica/web/filter/OpenClinicaSessionRegistryImpl.java
+++ b/web/src/main/java/org/akaza/openclinica/web/filter/OpenClinicaSessionRegistryImpl.java
@@ -6,6 +6,7 @@ import java.util.Locale;
 import javax.sql.DataSource;
 
 import org.akaza.openclinica.bean.login.UserAccountBean;
+import org.akaza.openclinica.core.CRFLocker;
 import org.akaza.openclinica.dao.hibernate.AuditUserLoginDao;
 import org.akaza.openclinica.dao.login.UserAccountDAO;
 import org.akaza.openclinica.domain.technicaladmin.AuditUserLoginBean;
@@ -21,6 +22,7 @@ public class OpenClinicaSessionRegistryImpl extends SessionRegistryImpl {
     AuditUserLoginDao auditUserLoginDao;
     UserAccountDAO userAccountDao;
     DataSource dataSource;
+    CRFLocker crfLocker;
 
     @Override
     public void removeSessionInformation(String sessionId) {
@@ -43,6 +45,8 @@ public class OpenClinicaSessionRegistryImpl extends SessionRegistryImpl {
     void auditLogout(String username) {
         ResourceBundleProvider.updateLocale(new Locale("en_US"));
         UserAccountBean userAccount = (UserAccountBean) getUserAccountDao().findByUserName(username);
+        crfLocker.unlockAllForUser(userAccount.getId());
+
         AuditUserLoginBean auditUserLogin = new AuditUserLoginBean();
         auditUserLogin.setUserName(username);
         auditUserLogin.setLoginStatus(LoginStatus.SUCCESSFUL_LOGOUT);
@@ -69,5 +73,9 @@ public class OpenClinicaSessionRegistryImpl extends SessionRegistryImpl {
 
     public void setAuditUserLoginDao(AuditUserLoginDao auditUserLoginDao) {
         this.auditUserLoginDao = auditUserLoginDao;
+    }
+
+    public void setCrfLocker(CRFLocker crfLocker) {
+        this.crfLocker = crfLocker;
     }
 }

--- a/web/src/main/resources/org/akaza/openclinica/applicationContext-security.xml
+++ b/web/src/main/resources/org/akaza/openclinica/applicationContext-security.xml
@@ -100,6 +100,7 @@
      <bean id="sessionRegistry" class="org.akaza.openclinica.web.filter.OpenClinicaSessionRegistryImpl">
         <property name="auditUserLoginDao" ref="auditUserLoginDao"/>
         <property name="dataSource" ref="dataSource"/>
+         <property name="crfLocker" ref="crfLocker" />
      </bean>
     
     


### PR DESCRIPTION
The CRFLocker was not cleared when a session-time out occurs. Tested this fix by changing the session-time in the datainfo.properties to 20 seconds and waiting until the auditLogout method of the OpenClinicaSessionRegistryImpl was triggered. 
* this change was not included in the OpenClinica-ws source because I noticed that the OpenClinicaUsernamePasswordAuthenticationFilter class in the WS-war does not use the CRFLocker.
* the OpenClinicaSessionRegistryImpl in the WS does not retrieve the user information from LDAP, the Web however it does use LDAP.