### PR TITLE
OC-6483 Notification Rule with more than 255 characters in <Message> and <Subject> elements generate Oops Error

### DIFF
--- a/core/src/main/resources/migration/3.9/2015-12-07-OC-6483.xml
+++ b/core/src/main/resources/migration/3.9/2015-12-07-OC-6483.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+
+	<changeSet author="jkeremian" id="2015-12-07-OC-6483-01" dbms="postgresql">
+		<comment>Change character width for Message and Email_subject columns of Rule Action Table</comment>
+		<sql>
+        ALTER TABLE rule_action ALTER COLUMN message TYPE varchar(2040);
+        ALTER TABLE rule_action ALTER COLUMN email_subject TYPE varchar(1020);
+ </sql>
+		<rollback>
+			<sql></sql>
+		</rollback>
+	</changeSet>
+
+
+
+</databaseChangeLog>
+    
+    

--- a/core/src/main/resources/migration/3.9/release.xml
+++ b/core/src/main/resources/migration/3.9/release.xml
@@ -3,4 +3,5 @@
        <include file="migration/3.9/2015-11-18-OC-6777.xml"/>
        <include file="migration/3.9/2015-11-12-OC-6820.xml"/>
        <include file="migration/3.9/2015-11-18-OC-6825.xml"/>
+       <include file="migration/3.9/2015-12-07-OC-6483.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
Notification Rule with more than 255 characters in <Message> and
<Subject> elements generate Oops Error