### PR TITLE
Oc 2047 Rules not working when absolute paths (versus relative paths) are used in the expression or action

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/domain/rule/action/RuleActionBean.java
+++ b/core/src/main/java/org/akaza/openclinica/domain/rule/action/RuleActionBean.java
@@ -147,6 +147,11 @@ public class RuleActionBean extends AbstractAuditableMutableDomainObject impleme
                 return false;
         } else if (!summary.equals(other.summary))
             return false;
+        if (ruleActionRun == null) {
+            if (other.ruleActionRun != null)
+                return false;
+        } else if (!ruleActionRun.equals(other.ruleActionRun))
+            return false;
         return true;
     }
 

--- a/core/src/main/java/org/akaza/openclinica/service/rule/RulesPostImportContainerService.java
+++ b/core/src/main/java/org/akaza/openclinica/service/rule/RulesPostImportContainerService.java
@@ -370,10 +370,6 @@ public class RulesPostImportContainerService {
 		if (ruleActionBean instanceof org.akaza.openclinica.domain.rule.action.NotificationActionBean){
 			 message = ((NotificationActionBean) ruleActionBean).getMessage();
 			 emailSubject = ((NotificationActionBean) ruleActionBean).getSubject();
-			if (emailSubject.length() > 255) 
-			ruleSetBeanWrapper.error(createError("OCRERR_0048"));
-			if (message.length() > 255) 
-			ruleSetBeanWrapper.error(createError("OCRERR_0049"));		
 		}
 
 		if (ruleActionBean instanceof org.akaza.openclinica.domain.rule.action.EmailActionBean)

--- a/core/src/main/resources/org/akaza/openclinica/i18n/page_messages.properties
+++ b/core/src/main/resources/org/akaza/openclinica/i18n/page_messages.properties
@@ -1152,8 +1152,6 @@ OCRERR_0044= Event Action can only be used with a Target of STARTDATE or STATUS.
 OCRERR_0045= The action you have specified is not supported for a Target of STATUS or STARTDATE. "EventAction" is the supported action for the given Target.
 OCRERR_0046= CRF Items or incorrect Properties [such as: {0}] are not supported in Expression and Value Expression when using EventAction.
 OCRERR_0047= The "Time" attribute in RunOnStatus element should have the following format "HH:mm" and range "00:00 - 23:59".
-OCRERR_0048= The "Subject" element for Notification Action should not exceed 255 characters.
-OCRERR_0049= The "Message" element for Notification Action should not exceed 255 characters.
 OCRERR_0050= All of the run on parameters are set to false, please edit your rule and make sure you have at least one of the run on parameter is set to True 
 OCRERR_0051= In Randomize Action, The Study Subject Parameter "{0}" within Stratification Factor is not Valid.
 

--- a/web/src/main/resources/org/akaza/openclinica/i18n/page_messages.properties
+++ b/web/src/main/resources/org/akaza/openclinica/i18n/page_messages.properties
@@ -1152,8 +1152,6 @@ OCRERR_0044= Event Action can only be used with a Target of STARTDATE or STATUS.
 OCRERR_0045= The action you have specified is not supported for a Target of STATUS or STARTDATE. "EventAction" is the supported action for the given Target.
 OCRERR_0046= CRF Items or incorrect Properties [such as: {0}] are not supported in Expression and Value Expression when using EventAction.
 OCRERR_0047= The "Time" attribute in RunOnStatus element should have the following format "HH:mm" and range "00:00 - 23:59".
-OCRERR_0048= The "Subject" element for Notification Action should not exceed 255 characters.
-OCRERR_0049= The "Message" element for Notification Action should not exceed 255 characters.
 OCRERR_0050= All of the run on parameters are set to false, please edit your rule and make sure you have at least one of the run on parameter is set to True 
 OCRERR_0051= In Randomize Action, The Study Subject Parameter "{0}" within Stratification Factor is not Valid.
 


### PR DESCRIPTION
Rules not working when absolute paths (versus relative paths) are used in the expression or action