### PR TITLE
OC-6483 Added validation to avoid oops page on upload for characters/ bytes over specified #

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/service/rule/RulesPostImportContainerService.java
+++ b/core/src/main/java/org/akaza/openclinica/service/rule/RulesPostImportContainerService.java
@@ -370,6 +370,10 @@ public class RulesPostImportContainerService {
 		if (ruleActionBean instanceof org.akaza.openclinica.domain.rule.action.NotificationActionBean){
 			 message = ((NotificationActionBean) ruleActionBean).getMessage();
 			 emailSubject = ((NotificationActionBean) ruleActionBean).getSubject();
+			if (emailSubject.length() > 510) 
+			ruleSetBeanWrapper.error(createError("OCRERR_0048"));
+			if (message.length() > 2040) 
+			ruleSetBeanWrapper.error(createError("OCRERR_0049"));		
 		}
 
 		if (ruleActionBean instanceof org.akaza.openclinica.domain.rule.action.EmailActionBean)

--- a/core/src/main/resources/org/akaza/openclinica/i18n/page_messages.properties
+++ b/core/src/main/resources/org/akaza/openclinica/i18n/page_messages.properties
@@ -1152,6 +1152,8 @@ OCRERR_0044= Event Action can only be used with a Target of STARTDATE or STATUS.
 OCRERR_0045= The action you have specified is not supported for a Target of STATUS or STARTDATE. "EventAction" is the supported action for the given Target.
 OCRERR_0046= CRF Items or incorrect Properties [such as: {0}] are not supported in Expression and Value Expression when using EventAction.
 OCRERR_0047= The "Time" attribute in RunOnStatus element should have the following format "HH:mm" and range "00:00 - 23:59".
+OCRERR_0048= The "Subject" element for Notification Action should not exceed 1020 characters.
+OCRERR_0049= The "Message" element for Notification Action should not exceed 2040 characters.
 OCRERR_0050= All of the run on parameters are set to false, please edit your rule and make sure you have at least one of the run on parameter is set to True 
 OCRERR_0051= In Randomize Action, The Study Subject Parameter "{0}" within Stratification Factor is not Valid.
 

--- a/web/src/main/resources/org/akaza/openclinica/i18n/page_messages.properties
+++ b/web/src/main/resources/org/akaza/openclinica/i18n/page_messages.properties
@@ -1152,6 +1152,8 @@ OCRERR_0044= Event Action can only be used with a Target of STARTDATE or STATUS.
 OCRERR_0045= The action you have specified is not supported for a Target of STATUS or STARTDATE. "EventAction" is the supported action for the given Target.
 OCRERR_0046= CRF Items or incorrect Properties [such as: {0}] are not supported in Expression and Value Expression when using EventAction.
 OCRERR_0047= The "Time" attribute in RunOnStatus element should have the following format "HH:mm" and range "00:00 - 23:59".
+OCRERR_0048= The "Subject" element for Notification Action should not exceed 1020 characters.
+OCRERR_0049= The "Message" element for Notification Action should not exceed 2040 characters.
 OCRERR_0050= All of the run on parameters are set to false, please edit your rule and make sure you have at least one of the run on parameter is set to True 
 OCRERR_0051= In Randomize Action, The Study Subject Parameter "{0}" within Stratification Factor is not Valid.
 


### PR DESCRIPTION
Notification Rule with more than 255 characters in <Message> and
<Subject> elements generate Oops Error