### PR TITLE
OC-1176 Validating rule_expression_value length at rule upload to OC

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/logic/expressionTree/OpenClinicaExpressionParser.java
+++ b/core/src/main/java/org/akaza/openclinica/logic/expressionTree/OpenClinicaExpressionParser.java
@@ -82,6 +82,8 @@ public class OpenClinicaExpressionParser {
     }
 
     public String parseAndTestEvaluateExpression(String expression) throws OpenClinicaSystemException {
+        if(expression.length()>2040)
+            throw new OpenClinicaSystemException("OCRERR_0052");
         getTextIO().fillBuffer(expression);
         getTextIO().skipBlanks();
         ExpressionNode exp = expressionTree();

--- a/core/src/main/resources/org/akaza/openclinica/i18n/page_messages.properties
+++ b/core/src/main/resources/org/akaza/openclinica/i18n/page_messages.properties
@@ -1156,6 +1156,7 @@ OCRERR_0048= The "Subject" element for Notification Action should not exceed 330
 OCRERR_0049= The "Message" element for Notification Action should not exceed 2040 characters.
 OCRERR_0050= All of the run on parameters are set to false, please edit your rule and make sure you have at least one of the run on parameter is set to True
 OCRERR_0051= In Randomize Action, The Study Subject Parameter "{0}" within Stratification Factor is not Valid.
+OCRERR_0052= Syntax Error in Expression.Rule Expression length exceeds 2040 characters.
 
 rules_Import_message1= Congratulations! Your Rule import passed with no errors. Review the Rule validation results. You can save it to the database by clicking "Continue".
 rules_Import_message2= Congratulations! Your Rule import passed with no errors. Some existing Rules or Rule assignments will be updated or replaced. Review the Rule validation results. You can save it to the database by clicking "Continue".

--- a/web/src/main/resources/org/akaza/openclinica/i18n/page_messages.properties
+++ b/web/src/main/resources/org/akaza/openclinica/i18n/page_messages.properties
@@ -1156,6 +1156,7 @@ OCRERR_0048= The "Subject" element for Notification Action should not exceed 330
 OCRERR_0049= The "Message" element for Notification Action should not exceed 2040 characters.
 OCRERR_0050= All of the run on parameters are set to false, please edit your rule and make sure you have at least one of the run on parameter is set to True
 OCRERR_0051= In Randomize Action, The Study Subject Parameter "{0}" within Stratification Factor is not Valid.
+OCRERR_0052= Syntax Error in Expression.Rule Expression length exceeds 2040 characters.
 
 
 


### PR DESCRIPTION
Extend rule_expression.value data type beyond 1025 characters