### PR TITLE
OC-2047 Absolute vs Relative Rule Expression

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/service/rule/expression/ExpressionService.java
+++ b/core/src/main/java/org/akaza/openclinica/service/rule/expression/ExpressionService.java
@@ -453,7 +453,10 @@ public class ExpressionService {
                      }
                      logger.debug("valueFromDb : {}", valueFromDb);
                      value = valueFromForm == null ? valueFromDb : valueFromForm;
-                    
+                     if (value == null) {
+                         logger.info("The value is " + value + "  for expression" + expression);
+                         throw new OpenClinicaSystemException("OCRERR_0018", new Object[] { expression });
+                     }
                      
                  }
              }


### PR DESCRIPTION
Rules not working when absolute paths (versus relative paths) are used
in the expression or action