### PR TITLE
Oc 7136 OC doesn't allow user to Mark CRF Complete when required item is not answered but has a Discrepancy Note

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/bean/extract/odm/ClinicalDataReportBean.java
+++ b/core/src/main/java/org/akaza/openclinica/bean/extract/odm/ClinicalDataReportBean.java
@@ -170,7 +170,7 @@ public class ClinicalDataReportBean extends OdmXmlReportBean {
 
                         ArrayList<ImportItemDataBean> items = new ArrayList<>();          
                         for (ImportItemDataBean item : itemList) {
-                            if (item.getValue().trim().length()!=0){
+                            if (item.getValue()!=null && item.getValue().trim().length()!=0){
                                 items.add(item);
                             }                            
                         }

--- a/web/src/main/java/org/akaza/openclinica/control/submit/DataEntryServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/DataEntryServlet.java
@@ -4173,7 +4173,7 @@ public abstract class DataEntryServlet extends CoreSecureController {
                 return false;
             for (ItemDataBean itemdata : itemdatas) {
                 System.out.println(itemdata.getItemId() +"  :  "+   itemdata.getValue());
-                if (itemdata.getValue()==null || itemdata.getValue().equals(null)  || itemdata.getValue().equals("") || itemdata.getValue().length()==0 || itemdata.getValue().isEmpty()) {
+                if ((itemdata.getValue()==null || itemdata.getValue().equals("") || itemdata.getValue().trim().length()==0) && dndao.findNumExistingNotesForItem(itemdata.getId())<1 ) {
                     return false;
                 }
             }
@@ -4188,7 +4188,7 @@ public abstract class DataEntryServlet extends CoreSecureController {
                 return false;
             }
             for (ItemDataBean itemdata : itemdatas) {
-                if (itemdata.getValue() == null && dynamicsItemFormMetadataBeans.size() > 0) {
+                if ((itemdata.getValue()==null || itemdata.getValue().equals("") || itemdata.getValue().trim().length()==0) && dndao.findNumExistingNotesForItem(itemdata.getId())<1 && dynamicsItemFormMetadataBeans.size() > 0) {
                         return false;
                 }
             }


### PR DESCRIPTION
OC doesn't allow user to Mark CRF Complete when required item is not answered but has a Discrepancy Note