### PR TITLE
Some .gitignore improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ release.properties
 .classpath
 .project
 .settings/
-.idea/
 web/src/main/resources/datainfo.properties
 .DS_Store
 core/.DS_Store
@@ -15,11 +14,8 @@ web/.DS_Store
 ws/.DS_Store
 
 # intellij idea
+.idea/
 *.iml
-core/*.iml
-web/*.iml
-ws/*.iml
-stormpath/*.iml
 
 # git
 *.orig

--- a/.gitignore
+++ b/.gitignore
@@ -8,22 +8,21 @@ release.properties
 .project
 .settings/
 .idea/
-OpenClinica.iml
 web/src/main/resources/datainfo.properties
-core/*.iml
-web/*.iml
-ws/*.iml
 .DS_Store
 core/.DS_Store
 web/.DS_Store
 ws/.DS_Store
 
+# intellij idea
+*.iml
+core/*.iml
+web/*.iml
+ws/*.iml
+stormpath/*.iml
+
 # git
 *.orig
-/ws/*.iml
-/web/OpenClinica-web.iml
-/core/OpenClinica-core.iml
-/core/OpenClinica-core.iml
 
 # netbeans
 nb-configuration.xml


### PR DESCRIPTION
I just noticed that Idea generated `stormpath/Stormpath.iml` file which was not excluded from version control. Then I started fixing that and made some cleaning in `.gitignore`. Maybe those changes will be useful for you as well. 
I've done the following changes:
- instead of mentioning file by file I've just excluded all the *.iml files from version control;
- moved all the IntelliJ related lines to special block(similar to Git and NetBeans blocks).
Please, accept this pull request if you think that it makes sense.