### PR TITLE
OC7499 : Now, empty end date events can be saved.

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/UpdateStudyEventServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/UpdateStudyEventServlet.java
@@ -397,6 +397,9 @@ public class UpdateStudyEventServlet extends SecureController {
                     } else {
                         studyEvent.setEndTimeFlag(true);
                     }
+                }else{
+                	//In case of empty value
+                	studyEvent.setDateEnded(end);
                 }
 
                 studyEvent.setLocation(fp.getString(INPUT_LOCATION));
@@ -464,6 +467,9 @@ public class UpdateStudyEventServlet extends SecureController {
                     } else {
                         studyEvent.setEndTimeFlag(true);
                     }
+                }else{
+                	//In case of empty value
+                	studyEvent.setDateEnded(end);
                 }
                 // YW >>
                 studyEvent.setLocation(fp.getString(INPUT_LOCATION));


### PR DESCRIPTION
Fixed.

View this error at https://jira.openclinica.com/browse/OC-7499
