### PR TITLE
OC-6088: fix for the problem that the existing CRF-template is overwr…

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/control/admin/CreateCRFVersionServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/admin/CreateCRFVersionServlet.java
@@ -43,6 +43,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -408,7 +409,15 @@ public class CreateCRFVersionServlet extends SecureController {
                 session.setAttribute("version", version);
                 return tempFile;
 
-            } else {
+            }
+            else if (DownloadVersionSpreadSheetServlet.CRF_VERSION_TEMPLATE.equalsIgnoreCase(f.getName().toUpperCase())) {
+                // ignore case because some insentive OS's use case-insentive FileSystems.
+                String error = MessageFormat.format(respage.getString("error.crfupload.filename.equal.to.template"), DownloadVersionSpreadSheetServlet.CRF_VERSION_TEMPLATE);
+                Validator.addError(errors, "excel_file", error);
+                session.setAttribute("version", version);
+                return tempFile;
+            }
+            else {
                 logger.debug("file name:" + f.getName());
                 tempFile = f.getName();
                 // create the inputstream here, so that it can be enclosed in a

--- a/web/src/main/resources/org/akaza/openclinica/i18n/page_messages.properties
+++ b/web/src/main/resources/org/akaza/openclinica/i18n/page_messages.properties
@@ -233,6 +233,8 @@ file_upload_error_occurred = Error details: "{0}".
 
 file_you_uploaded_not_seem_excel_spreadsheet = The file you uploaded does not seem to be an Excel spreadsheet.
 
+error.crfupload.filename.equal.to.template = The uploaded file must have a different name than the blanc CRF template "{0}".
+
 file_you_uploaded_not_seem_xml_file = The file you uploaded does not seem to be an XML file.
 
 filepath_you_defined_not_seem_valid = The filePath you defined in datainfo.properties does not seem to be a valid path. Please check it.


### PR DESCRIPTION
Hi Krikor, 
Cal asked me last Friday to commit a PR for OC-6088. The problem was that the server-side CRF-template was overwritten when a user uploaded a new CRF-file with the same name as the template. 

regards, Jacob