### PR TITLE
OC-8055 Oops Error occurs when attempting to view metadata of a second CRF AFTER uploading the first CRF

### DIFF
--- a/core/src/main/resources/properties/item_form_metadata_dao.xml
+++ b/core/src/main/resources/properties/item_form_metadata_dao.xml
@@ -269,7 +269,7 @@
 		<name>findByItemIdAndFormLayoutIdNotInIGM</name>
 		<sql>
 			SELECT m.*, rs.response_type_id, rs.label, rs.options_text, rs.options_values
-			FROM item_form_metadata m, response_set rs , form_layout_id fl ,versioning_map vm
+			FROM item_form_metadata m, response_set rs , form_layout fl ,versioning_map vm
 			WHERE m.item_id=?
 				AND fl.form_layout_id=?
 				AND vm.form_layout_id = fl.form_layout_id


### PR DESCRIPTION
Oops Error occurs when attempting to view metadata of a second CRF AFTER
uploading the first CRF