### PR TITLE
Adding JsonIgnoreProperties to OCUserDTO to prevent OC from breaking

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/controller/helper/OCUserDTO.java
+++ b/web/src/main/java/org/akaza/openclinica/controller/helper/OCUserDTO.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 /**
  * A DTO for the OCUser entity.
  */
+@com.fasterxml.jackson.annotation.JsonIgnoreProperties (ignoreUnknown = true)
 public class OCUserDTO extends AbstractAuditingDTO implements Serializable {
 
     private String uuid;


### PR DESCRIPTION
Adding JsonIgnoreProperties to OCUserDTO to prevent OC from breaking in case new properties are added to SBS before being added to Bridge