### PR TITLE
4x update query icon colors new

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/bean/core/ResolutionStatus.java
+++ b/core/src/main/java/org/akaza/openclinica/bean/core/ResolutionStatus.java
@@ -33,7 +33,7 @@ public class ResolutionStatus extends Term {
 
     public static final ResolutionStatus OPEN = new ResolutionStatus(1, "New", null, "fa fa-bubble-red");
 
-    public static final ResolutionStatus UPDATED = new ResolutionStatus(2, "Updated", null, "fa fa-bubble-yellow");
+    public static final ResolutionStatus UPDATED = new ResolutionStatus(2, "Updated", null, "fa fa-bubble-orange");
 
     public static final ResolutionStatus RESOLVED = new ResolutionStatus(3, "Resolution_Proposed", null, "");
 

--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/UpdateStudyEventServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/UpdateStudyEventServlet.java
@@ -86,8 +86,11 @@ public class UpdateStudyEventServlet extends SecureController {
     public static final String INPUT_LOCATION = "location";
 
     public final static String HAS_LOCATION_NOTE = "hasLocationNote";
+    public final static String LOCATION_NOTE = "locationNote";
     public final static String HAS_START_DATE_NOTE = "hasStartDateNote";
+    public final static String START_DATE_NOTE = "startDateNote";
     public final static String HAS_END_DATE_NOTE = "hasEndDateNote";
+    public final static String END_DATE_NOTE = "endDateNote";
 
 
     @Override
@@ -799,11 +802,13 @@ public class UpdateStudyEventServlet extends SecureController {
         for (DiscrepancyNoteBean discrepancyNoteBean : discBeans) {
             if ("location".equalsIgnoreCase(discrepancyNoteBean.getColumn())) {
                 request.setAttribute(HAS_LOCATION_NOTE, "yes");
+                request.setAttribute(LOCATION_NOTE, discrepancyNoteBean);
             } else if ("start_date".equalsIgnoreCase(discrepancyNoteBean.getColumn())) {
                 request.setAttribute(HAS_START_DATE_NOTE, "yes");
-
+                request.setAttribute(START_DATE_NOTE, discrepancyNoteBean);
             } else if ("end_date".equalsIgnoreCase(discrepancyNoteBean.getColumn())) {
                 request.setAttribute(HAS_END_DATE_NOTE, "yes");
+                request.setAttribute(END_DATE_NOTE, discrepancyNoteBean);
             }
 
         }

--- a/web/src/main/java/org/akaza/openclinica/control/submit/EnterDataForStudyEventServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/EnterDataForStudyEventServlet.java
@@ -71,14 +71,17 @@ public class EnterDataForStudyEventServlet extends SecureController {
     // property; this
     // value will be saved as a request attribute
     public final static String HAS_LOCATION_NOTE = "hasLocationNote";
+    public final static String LOCATION_NOTE = "locationNote";
     // The study event has an existing discrepancy note related to its start
     // date property; this
     // value will be saved as a request attribute
     public final static String HAS_START_DATE_NOTE = "hasStartDateNote";
+    public final static String START_DATE_NOTE = "startDateNote";
     // The study event has an existing discrepancy note related to its end date
     // property; this
     // value will be saved as a request attribute
     public final static String HAS_END_DATE_NOTE = "hasEndDateNote";
+    public final static String END_DATE_NOTE = "endDateNote";
 
     private StudyEventBean getStudyEvent(int eventId) throws Exception {
         StudyEventDAO sedao = new StudyEventDAO(sm.getDataSource());
@@ -624,11 +627,14 @@ public class EnterDataForStudyEventServlet extends SecureController {
         for (DiscrepancyNoteBean discrepancyNoteBean : discBeans) {
             if ("location".equalsIgnoreCase(discrepancyNoteBean.getColumn())) {
                 request.setAttribute(HAS_LOCATION_NOTE, "yes");
+                request.setAttribute(LOCATION_NOTE, discrepancyNoteBean);
             } else if ("start_date".equalsIgnoreCase(discrepancyNoteBean.getColumn())) {
                 request.setAttribute(HAS_START_DATE_NOTE, "yes");
+                request.setAttribute(START_DATE_NOTE, discrepancyNoteBean);
 
             } else if ("end_date".equalsIgnoreCase(discrepancyNoteBean.getColumn())) {
                 request.setAttribute(HAS_END_DATE_NOTE, "yes");
+                request.setAttribute(END_DATE_NOTE, discrepancyNoteBean);
             }
 
         }

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudyEvent.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudyEvent.jsp
@@ -127,11 +127,11 @@
                     <c:choose>
                         <c:when test="${hasStartDateNote eq 'yes'}">
                             <a href="#" onClick="openDNoteWindow('ViewDiscrepancyNote?writeToDB=1&id=${studyEvent.id}&subjectId=${studySubject.id}&name=studyEvent&field=start_date&column=start_date&strErrMsg','spanAlert-start_date'); return false;"
-                                    ><span id="flag_start_date" name="flag_start_date" class="fa fa-bubble-red" border="0" alt="<fmt:message key="discrepancy_note" bundle="${resword}"/>" title="<fmt:message key="discrepancy_note" bundle="${resword}"/>"></a>
+                                    ><span id="flag_start_date" name="flag_start_date" class="${startDateNote.resStatus.iconFilePath}" border="0" alt="<fmt:message key="discrepancy_note" bundle="${resword}"/>" title="<fmt:message key="discrepancy_note" bundle="${resword}"/>"></a>
                         </c:when>
                         <c:otherwise>
                             <c:if test="${!study.status.locked}">
-                                <a href="#" onClick="openDNoteWindow('CreateDiscrepancyNote?writeToDB=1&id=${studyEvent.id}&subjectId=${studySubject.id}&name=studyEvent&field=start_date&column=start_date&strErrMsg','spanAlert-start'); return false;"><span id="flag_start_date" name="flag_start_date" class="fa fa-bubble-black" border="0" alt="<fmt:message key="discrepancy_note" bundle="${resword}"/>" title="<fmt:message key="discrepancy_note" bundle="${resword}"/>"></a>
+                                <a href="#" onClick="openDNoteWindow('CreateDiscrepancyNote?writeToDB=1&id=${studyEvent.id}&subjectId=${studySubject.id}&name=studyEvent&field=start_date&column=start_date&strErrMsg','spanAlert-start'); return false;"><span id="flag_start_date" name="flag_start_date" class="fa fa-bubble-white" border="0" alt="<fmt:message key="discrepancy_note" bundle="${resword}"/>" title="<fmt:message key="discrepancy_note" bundle="${resword}"/>"></a>
                             </c:if>
                         </c:otherwise>
                     </c:choose>
@@ -155,11 +155,11 @@
                     <c:choose>
                         <c:when test="${hasEndDateNote eq 'yes'}">
                             <a href="#" onClick="openDNoteWindow('ViewDiscrepancyNote?writeToDB=1&id=${studyEvent.id}&subjectId=${studySubject.id}&name=studyEvent&field=end_date&column=end_date&strErrMsg','spanAlert-start_date'); return false;"
-                                    ><span id="flag_end_date" name="flag_end_date" class="fa fa-bubble-red" border="0" alt="<fmt:message key="discrepancy_note" bundle="${resword}"/>" title="<fmt:message key="discrepancy_note" bundle="${resword}"/>"></a>
+                                    ><span id="flag_end_date" name="flag_end_date" class="${endDateNote.resStatus.iconFilePath}" border="0" alt="<fmt:message key="discrepancy_note" bundle="${resword}"/>" title="<fmt:message key="discrepancy_note" bundle="${resword}"/>"></a>
                         </c:when>
                         <c:otherwise>
                             <c:if test="${!study.status.locked}">
-                                <a href="#" onClick="openDNoteWindow('CreateDiscrepancyNote?writeToDB=1&id=${studyEvent.id}&subjectId=${studySubject.id}&name=studyEvent&field=end_date&column=end_date&strErrMsg','spanAlert-start'); return false;"><span id="flag_end_date" name="flag_end_date" class="fa fa-bubble-black" border="0" alt="<fmt:message key="discrepancy_note" bundle="${resword}"/>" title="<fmt:message key="discrepancy_note" bundle="${resword}"/>"></a>
+                                <a href="#" onClick="openDNoteWindow('CreateDiscrepancyNote?writeToDB=1&id=${studyEvent.id}&subjectId=${studySubject.id}&name=studyEvent&field=end_date&column=end_date&strErrMsg','spanAlert-start'); return false;"><span id="flag_end_date" name="flag_end_date" class="fa fa-bubble-white" border="0" alt="<fmt:message key="discrepancy_note" bundle="${resword}"/>" title="<fmt:message key="discrepancy_note" bundle="${resword}"/>"></a>
                             </c:if>
                         </c:otherwise>
                     </c:choose>
@@ -184,11 +184,11 @@
           <c:choose>
               <c:when test="${hasLocationNote eq 'yes'}">
                   <a href="#" onClick="openDNoteWindow('ViewDiscrepancyNote?writeToDB=1&id=${studyEvent.id}&subjectId=${studySubject.id}&name=studyEvent&field=location&column=location&strErrMsg','spanAlert-start_date'); return false;"
-                          ><span id="flag_location" name="flag_location" class="fa fa-bubble-red" border="0" alt="<fmt:message key="discrepancy_note" bundle="${resword}"/>" title="<fmt:message key="discrepancy_note" bundle="${resword}"/>"></a>
+                          ><span id="flag_location" name="flag_location" class="${locationNote.resStatus.iconFilePath}" border="0" alt="<fmt:message key="discrepancy_note" bundle="${resword}"/>" title="<fmt:message key="discrepancy_note" bundle="${resword}"/>"></a>
               </c:when>
               <c:otherwise>
                   <c:if test="${!study.status.locked}">
-                      <a href="#" onClick="openDNoteWindow('CreateDiscrepancyNote?writeToDB=1&id=${studyEvent.id}&subjectId=${studySubject.id}&name=studyEvent&field=location&column=location&strErrMsg','spanAlert-start'); return false;"><span id="flag_location" name="flag_start" class="fa fa-bubble-black" border="0" alt="<fmt:message key="discrepancy_note" bundle="${resword}"/>" title="<fmt:message key="discrepancy_note" bundle="${resword}"/>"></a>
+                      <a href="#" onClick="openDNoteWindow('CreateDiscrepancyNote?writeToDB=1&id=${studyEvent.id}&subjectId=${studySubject.id}&name=studyEvent&field=location&column=location&strErrMsg','spanAlert-start'); return false;"><span id="flag_location" name="flag_start" class="fa fa-bubble-white" border="0" alt="<fmt:message key="discrepancy_note" bundle="${resword}"/>" title="<fmt:message key="discrepancy_note" bundle="${resword}"/>"></a>
                   </c:if>
               </c:otherwise>
           </c:choose>

--- a/web/src/main/webapp/WEB-INF/jsp/submit/enterDataForStudyEvent.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/enterDataForStudyEvent.jsp
@@ -140,7 +140,7 @@
                                 <c:choose>
                                     <c:when test="${hasLocationNote eq 'yes'}">
                                      <span style="float:right"><a href="#" onClick="openDNoteWindow('ViewDiscrepancyNote?writeToDB=1&id=${studyEvent.id}&subjectId=${studySubject.id}&name=studyEvent&field=location&column=location&strErrMsg','spanAlert-location'); return false;">
-                                     <span id="flag_location" name="flag_location" class="fa fa-bubble-red" border="0" alt="<fmt:message key="discrepancy_note" bundle="${resword}"/>" title="<fmt:message key="discrepancy_note" bundle="${resword}"/>" >
+                                     <span id="flag_location" name="flag_location" class="${locationNote.resStatus.iconFilePath}" border="0" alt="<fmt:message key="discrepancy_note" bundle="${resword}"/>" title="<fmt:message key="discrepancy_note" bundle="${resword}"/>" >
                                      </a>
                                      </span>
                                     </c:when>
@@ -170,7 +170,7 @@
                                 <c:choose>
                                     <c:when test="${hasStartDateNote eq 'yes'}">
                                      <span style="float:right"><a href="#" onClick="openDNoteWindow('ViewDiscrepancyNote?writeToDB=1&id=${studyEvent.id}&subjectId=${studySubject.id}&name=studyEvent&field=start_date&column=start_date&strErrMsg','spanAlert-start_date'); return false;">
-                                     <span id="flag_start_date" name="flag_start_date" class="fa fa-bubble-red" border="0" alt="<fmt:message key="discrepancy_note" bundle="${resword}"/>" title="<fmt:message key="discrepancy_note" bundle="${resword}"/>" >
+                                     <span id="flag_start_date" name="flag_start_date" class="${startDateNote.resStatus.iconFilePath}" border="0" alt="<fmt:message key="discrepancy_note" bundle="${resword}"/>" title="<fmt:message key="discrepancy_note" bundle="${resword}"/>" >
                                      </a>
                                      </span>
                                     </c:when>
@@ -195,7 +195,7 @@
                                 <c:choose>
                                     <c:when test="${hasEndDateNote eq 'yes'}">
                                      <span style="float:right"><a href="#" onClick="openDNoteWindow('ViewDiscrepancyNote?writeToDB=1&id=${studyEvent.id}&subjectId=${studySubject.id}&name=studyEvent&field=end_date&column=end_date&strErrMsg','spanAlert-end_date'); return false;">
-                                     <span id="flag_end_date" name="flag_end_date" class="fa fa-bubble-red" border="0" alt="<fmt:message key="discrepancy_note" bundle="${resword}"/>" title="<fmt:message key="discrepancy_note" bundle="${resword}"/>" >
+                                     <span id="flag_end_date" name="flag_end_date" class="${endDateNote.resStatus.iconFilePath}" border="0" alt="<fmt:message key="discrepancy_note" bundle="${resword}"/>" title="<fmt:message key="discrepancy_note" bundle="${resword}"/>" >
                                      </a>
                                      </span>
                                     </c:when>

--- a/web/src/main/webapp/includes/global_functions_javascript.js
+++ b/web/src/main/webapp/includes/global_functions_javascript.js
@@ -1340,11 +1340,9 @@ function setImageInParentWin(strParentWinImageName,strParentWinImageFullPath) {
 
     if (window.opener && !window.opener.closed) {
         //alert(strParentWinImageName);
-        objImage = MM_findObjInParentWin(strParentWinImageName);
+        objImage = window.opener.document.getElementById(strParentWinImageName);
         if (objImage != null) {
-            //alert(objImage.name);
-            //alert(objImage.src);
-            objImage.src = strParentWinImageFullPath;
+            objImage.className = strParentWinImageFullPath;
         }
 
     }


### PR DESCRIPTION
Fixed issue where parent window query icon was not updated when a new Query was created.

Note: as with 3.x, this logic only applies to creating new queries.  Modifying an existing query does not update the parent window query icon.