### PR TITLE
Misc Cosmetic Issue Bridge

### DIFF
--- a/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
@@ -144,9 +144,9 @@
                             <table border="0" cellpadding="0" cellspacing="0" width="100%">
                                 <tr>
                                     <td>
-                                      <form METHOD="GET" action="ListStudySubjects" onSubmit=" if (document.forms[0]['findSubjects_f_studySubject.label'].value == 'Study Subject ID') { document.forms[0]['findSubjects_f_studySubject.label'].value=''}">
+                                      <form METHOD="GET" action="ListStudySubjects" onSubmit=" if (document.forms[0]['findSubjects_f_studySubject.label'].value == '<fmt:message key="study_subject_ID" bundle="${resword}"/>') { document.forms[0]['findSubjects_f_studySubject.label'].value=''}">
                                                                     <!--<a href="javascript:reportBug()">Report Issue</a>|-->
-                                            <input type="text" name="findSubjects_f_studySubject.label" onblur="if (this.value == '') this.value = 'Enter Study Subject ID'" onfocus="if (this.value == 'Study Subject ID') this.value = ''" value="Study Subject ID" class="navSearch"/>
+                                            <input type="text" name="findSubjects_f_studySubject.label" onblur="if (this.value == '') this.value = '<fmt:message key="study_subject_ID" bundle="${resword}"/>'" onfocus="if (this.value == '<fmt:message key="study_subject_ID" bundle="${resword}"/>') this.value = ''" value='<fmt:message key="study_subject_ID" bundle="${resword}"/>' class="navSearch"/>
                                             <input type="hidden" name="navBar" value="yes"/>
                                             <input type="submit" value="View &#8594;"  class="navSearchButton"/>
                                         </form>

--- a/web/src/main/webapp/WEB-INF/jsp/include/showTable.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/showTable.jsp
@@ -97,7 +97,7 @@
 				<tr>
 					<td valign="top">
 						<div class="formfieldM_BG">
-						<input name="ebl_filterKeyword" onblur="if (this.value == '') this.value = ''" onfocus="if (this.value == '<fmt:message key="study_subject_ID" bundle="${resword}"/>') this.value = ''" type="text" class="formfieldM" value="<fmt:message key="study_subject_ID" bundle="${resword}"/>"" /> 
+						<input name="ebl_filterKeyword" type="text" class="formfieldM" value="" /> 
 						</div> 
 					</td>
 					<td valign="top">

--- a/web/src/main/webapp/WEB-INF/jsp/showMessage.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/showMessage.jsp
@@ -4,19 +4,13 @@
 
 <%
 String key = request.getParameter("key");
-boolean hasMessages = false;
 if (formMessages.get(key)!=null) {
 	ArrayList messages = (ArrayList) formMessages.get(key);
 	if (messages !=null) {
 	  for (int messagecount = 0; messagecount < messages.size(); messagecount++) {
-		hasMessages = true;
         String message = (String) messages.get(messagecount);
-        %><div ID="spanAlert-<%=key%>" class="alert"><%=message%></div><%
+        %><div ID="spanAlert-<%=key%>" class="alert small"><%=message%></div><%
 	  }
     }
-}
-
-if (hasMessages) {
-	%><br /><br /><%
 }
 %>

--- a/web/src/main/webapp/WEB-INF/jsp/submit/addNewSubjectExpressNew.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/addNewSubjectExpressNew.jsp
@@ -74,358 +74,362 @@
 <form name="subjectForm" action="AddNewSubject" method="post">
 <input type="hidden" name="subjectOverlay" value="true">
 
-<div style="height: 475px; width:400px; background:#FFFFFF; cursor:default">
-<table border="0" cellpadding="0" align="center">
+<table border="0" cellpadding="0" align="center" style="cursor:default;">
     <tr style="height:10px;">
         <td class="formlabel" align="left"><h3 class="addNewSubjectTitle"><fmt:message key="add_new_subject" bundle="${resword}"/></h3></td>
     </tr>
     <tr>
         <td><div class="lines"></div></td>
-        <td><div class="lines"></div></td>
     </tr>
-    <tr valign="top">
-        <td class="formlabel" align="left">
-            <jsp:include page="../include/showSubmitted.jsp" />
-            <input class="form-control" type="hidden" name="addWithEvent" value="1"/><span class="addNewStudyLayout">
-            <fmt:message key="study_subject_ID" bundle="${resword}"/></span>&nbsp;<small class="required">*</small></td>
-        <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
-                <tr>
-                    <td valign="top"><div class="formfieldXL_BG">
-                    <c:choose>
-                     <c:when test="${study.studyParameterConfig.subjectIdGeneration =='auto non-editable'}">
-                      <input class="form-control" onfocus="this.select()" type="text" value="<c:out value="${label}"/>" size="45" class="formfield" disabled>
-                      <input class="form-control" type="hidden" name="label" value="<c:out value="${label}"/>">
-                     </c:when>
-                     <c:otherwise>
-                       <input class="form-control" onfocus="this.select()" type="text" name="label" value="<c:out value="${label}"/>" width="30" class="formfieldXL">
-                     </c:otherwise>
-                    </c:choose>
-                    </div></td>
-                </tr>
-                <tr>
-                    <td><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="label"/></jsp:include></td>
+    <tr>
+        <td>
+            <div style="max-height: 550px; min-width:400px; background:#FFFFFF; overflow-y: auto;">
+            <table>
+                <tr valign="top">
+                    <td class="formlabel" align="left">
+                        <jsp:include page="../include/showSubmitted.jsp" />
+                        <input class="form-control" type="hidden" name="addWithEvent" value="1"/><span class="addNewStudyLayout">
+                        <fmt:message key="study_subject_ID" bundle="${resword}"/></span>&nbsp;<small class="required">*</small></td>
+                    <td valign="top">
+                        <table border="0" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td valign="top"><div class="formfieldXL_BG">
+                                <c:choose>
+                                 <c:when test="${study.studyParameterConfig.subjectIdGeneration =='auto non-editable'}">
+                                  <input class="form-control" onfocus="this.select()" type="text" value="<c:out value="${label}"/>" size="45" class="formfield" disabled>
+                                  <input class="form-control" type="hidden" name="label" value="<c:out value="${label}"/>">
+                                 </c:when>
+                                 <c:otherwise>
+                                   <input class="form-control" onfocus="this.select()" type="text" name="label" value="<c:out value="${label}"/>" width="30" class="formfieldXL">
+                                 </c:otherwise>
+                                </c:choose>
+                                </div></td>
+                            </tr>
+                            <tr>
+                                <td><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="label"/></jsp:include></td>
+                            </tr>
+                            
+                        </table>
+                    </td>
                 </tr>
                 
-            </table>
-        </td>
-    </tr>
-    
-    <c:if test="${study.studyParameterConfig.secondaryLabelViewable =='true'}">
-    <tr valign="top">
-        <td class="formlabel" align="left">
-            <span class="addNewStudyLayout"><fmt:message key="secondary_ID" bundle="${resword}"/></span>
-        </td>
-        <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
-                <tr>        
-                    <td valign="top"><div class="formfieldXL_BG">
-                        <input class="form-control" onfocus="this.select()" type="text" name="secondaryLabel" value="<c:out value="${secondaryLabel}"/>" width="30" class="formfieldXL">
-                    </div></td>
-                    <td>&nbsp;</td>
-                </tr>
-                <tr>        
-                    <td><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="secondaryLabel"/></jsp:include></td>        
-                </tr>       
-            </table>        
-        </td>       
-    </tr>
-    </c:if>
-
-    <c:choose>
-    <c:when test="${study.studyParameterConfig.subjectPersonIdRequired =='required'}">
-    <tr valign="top">
-        <td class="formlabel" align="left">
-            <span class="addNewStudyLayout"><fmt:message key="person_ID" bundle="${resword}"/></span>&nbsp;<small class="required">*</small>
-        </td>
-        <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
-                <tr>
-                    <td valign="top"><div class="formfieldXL_BG">
-                        <input class="form-control" onfocus="this.select()" type="text" name="uniqueIdentifier" value="<c:out value="${uniqueIdentifier}"/>" width="30" class="formfieldXL">
-                    </div></td>
-                    <td>&nbsp;</td>
-                </tr>
-                <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="uniqueIdentifier"/></jsp:include></td>
-            </table>
-        </td>
-    </tr>
-    </c:when>
-    <c:when test="${study.studyParameterConfig.subjectPersonIdRequired =='optional'}">
-    <tr valign="top">
-        <td class="formlabel" align="left">
-            <span class="addNewStudyLayout"><fmt:message key="person_ID" bundle="${resword}"/></span>
-        </td>
-        <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
-                <tr>
-                    <td valign="top"><div class="formfieldXL_BG">
-                        <input class="form-control" onfocus="this.select()" type="text" name="uniqueIdentifier" value="<c:out value="${uniqueIdentifier}"/>" width="30" class="formfieldXL">
-                    </div></td>
-                    <td>&nbsp;</td>
-                </tr>
-                <tr>
-                    <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="uniqueIdentifier"/></jsp:include></td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-    </c:when>
-    <c:otherwise>
-      <input type="hidden" name="uniqueIdentifier" value="<c:out value="${uniqueIdentifier}"/>">
-    </c:otherwise>
-    </c:choose>
-
-    <tr valign="top" >
-
-        <td class="formlabel" align="left">
-            <span class="addNewStudyLayout"><fmt:message key="enrollment_date" bundle="${resword}"/></span>&nbsp;<small class="required">*</small>
-        </td>
-        <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
-                <tr>
+                <c:if test="${study.studyParameterConfig.secondaryLabelViewable =='true'}">
+                <tr valign="top">
+                    <td class="formlabel" align="left">
+                        <span class="addNewStudyLayout"><fmt:message key="secondary_ID" bundle="${resword}"/></span>
+                    </td>
                     <td valign="top">
-                        <a href="#">
-                             <span class="icon icon-calendarGB" alt="<fmt:message key="show_calendar" bundle="${resword}"/>" title="<fmt:message key="show_calendar" bundle="${resword}"/>" border="0" id="enrollmentDateTrigger" />
-                                <script type="text/javascript">
-                                Calendar.setup({inputField  : "enrollmentDateField", ifFormat    : "<fmt:message key="date_format_calender" bundle="${resformat}"/>", button      : "enrollmentDateTrigger", customPX: 300, customPY: 10 });
-                                </script>
-                            </a>
-                                
-                    </td>
-                    <td>
-                        <input class="form-control" onfocus="this.select()" type="text" name="enrollmentDate" size="16" value="<c:out value="${enrollmentDate}" />" class="formfieldM" id="enrollmentDateField" />
-                    </td>
+                        <table border="0" cellpadding="0" cellspacing="0">
+                            <tr>        
+                                <td valign="top"><div class="formfieldXL_BG">
+                                    <input class="form-control" onfocus="this.select()" type="text" name="secondaryLabel" value="<c:out value="${secondaryLabel}"/>" width="30" class="formfieldXL">
+                                </div></td>
+                                <td>&nbsp;</td>
+                            </tr>
+                            <tr>        
+                                <td><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="secondaryLabel"/></jsp:include></td>        
+                            </tr>       
+                        </table>        
+                    </td>       
                 </tr>
-               
-            </table>
-        </td>
-    </tr>
-     <tr>
-                    <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="enrollmentDate"/></jsp:include></td>
-                </tr>
+                </c:if>
 
-    <tr valign="top">
-        <c:if test="${study.studyParameterConfig.genderRequired !='not used'}">
-        <td class="formlabel" align="left">
-            <span class="addNewStudyLayout"><fmt:message key="gender" bundle="${resword}"/></span>
-            <c:choose>
-                <c:when test="${study.studyParameterConfig.genderRequired !='false'}">
-                   &nbsp;<small class="required">*</small>
+                <c:choose>
+                <c:when test="${study.studyParameterConfig.subjectPersonIdRequired =='required'}">
+                <tr valign="top">
+                    <td class="formlabel" align="left">
+                        <span class="addNewStudyLayout"><fmt:message key="person_ID" bundle="${resword}"/></span>&nbsp;<small class="required">*</small>
+                    </td>
+                    <td valign="top">
+                        <table border="0" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td valign="top"><div class="formfieldXL_BG">
+                                    <input class="form-control" onfocus="this.select()" type="text" name="uniqueIdentifier" value="<c:out value="${uniqueIdentifier}"/>" width="30" class="formfieldXL">
+                                </div></td>
+                                <td>&nbsp;</td>
+                            </tr>
+                            <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="uniqueIdentifier"/></jsp:include></td>
+                        </table>
+                    </td>
+                </tr>
                 </c:when>
-            </c:choose>
-        </td>
-        <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
-                <tr>
-                    <td valign="top"><div class="selectS">
-                        <select name="gender">
-                            <option value="">-<fmt:message key="select" bundle="${resword}"/>-</option>
-                            <c:choose>
-                                <c:when test="${!empty chosenGender}">
-                                    <c:choose>
-                                        <c:when test='${chosenGender == "m"}'>
-                                            <option value="m" selected><fmt:message key="male" bundle="${resword}"/></option>
-                                            <option value="f"><fmt:message key="female" bundle="${resword}"/></option>
-                                        </c:when>
-                                        <c:otherwise>
-                                            <option value="m"><fmt:message key="male" bundle="${resword}"/></option>
-                                            <option value="f" selected><fmt:message key="female" bundle="${resword}"/></option>
-                                        </c:otherwise>
-                                    </c:choose>
-                                </c:when>
-                                <c:otherwise>
-                                    <option value="m"><fmt:message key="male" bundle="${resword}"/></option>
-                                    <option value="f"><fmt:message key="female" bundle="${resword}"/></option>
-                                </c:otherwise>
-                            </c:choose>
-                            </select></div>
-                </td>
-    </tr>
-    </table>
-        </td>
-    </c:if>
-    </tr>
-    <tr>
-        <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="gender"/></jsp:include></td>
-    </tr>
-
-
-    <c:choose>
-    <c:when test="${study.studyParameterConfig.collectDob == '1'}">
-    <tr valign="top">
-        <td class="formlabel" align="left"><span class="addNewStudyLayout"><fmt:message key="date_of_birth" bundle="${resword}"/></span>&nbsp;<small class="required">*</small></td>
-        <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
-                <tr>
+                <c:when test="${study.studyParameterConfig.subjectPersonIdRequired =='optional'}">
+                <tr valign="top">
+                    <td class="formlabel" align="left">
+                        <span class="addNewStudyLayout"><fmt:message key="person_ID" bundle="${resword}"/></span>
+                    </td>
                     <td valign="top">
-                        <a href="#">
-                            <span class="icon icon-calendarGB" alt="<fmt:message key="show_calendar" bundle="${resword}"/>" title="<fmt:message key="show_calendar" bundle="${resword}"/>" border="0" id="dobTrigger" />
-                            <script type="text/javascript">
-                            Calendar.setup({inputField  : "dobField", ifFormat    : "<fmt:message key="date_format_calender" bundle="${resformat}"/>", button      : "dobTrigger", customPX: 300, customPY: 10 });
-                            </script>
-                        </a>    
-                    </td>
-                    <td>
-                        <input onfocus="this.select()" type="text" name="dob" size="16" value="<c:out value="${dob}" />" class="formfieldM form-control" id="dobField" />
-                    </td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-    <tr>
-        <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="dob"/></jsp:include></td>
-    </tr>
-
-    </c:when>
-    <c:when test="${study.studyParameterConfig.collectDob == '2'}">
-    <tr valign="top">
-        <td class="formlabel" align="left"><span class="addNewStudyLayout"><fmt:message key="year_of_birth" bundle="${resword}"/></span></td>
-        <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
-                <tr>
-                    <td valign="top"><div class="formfieldM_BG">
-                        <input onfocus="this.select()" type="text" name="yob" size="15" value="<c:out value="${yob}" />" class="formfieldM" />
-                    </td>
-                    <td>(<fmt:message key="date_format_year" bundle="${resformat}"/>) &nbsp;*</td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-    <tr>
-        <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="yob"/></jsp:include></td>
-    </tr>
-
-  </c:when>
-  <c:otherwise>
-    <input type="hidden" name="dob" value="" />
-  </c:otherwise>
- </c:choose>
-<c:if test="${(!empty studyGroupClasses)}">
-    <tr valign="top">
-      <td class="formlabel" align="right"><fmt:message key="subject_group_class" bundle="${resword}"/>:
-      <td class="table_cell">
-      <c:set var="count" value="0"/>
-      <table border="0" cellpadding="0">
-        <c:forEach var="group" items="${studyGroupClasses}">
-        <tr valign="top">
-         <td><b><c:out value="${group.name}"/></b></td>
-         <td><div class="formfieldM_BG">
-             <select name="studyGroupId<c:out value="${count}"/>" class="formfieldM">
-                 <option value=""><c:out value="${group.name}"/>:</option>
-                  <c:forEach var="studyGroup" items="${group.studyGroups}">
-                    <option value="<c:out value="${studyGroup.id}"/>"><c:out value="${studyGroup.name}"/></option>
-                  </c:forEach>
-              </select></div>
-             <c:import url="../showMessage.jsp"><c:param name="key" value="studyGroupId${count}" /></c:import>
-
-              </td>
-              <c:if test="${group.subjectAssignment=='Required'}">
-                <td align="left">&nbsp;*</td>
-              </c:if>
-              </tr>
-             <c:set var="count" value="${count+1}"/>
-        </c:forEach>
-        </table>
-      </td>
-    </tr>
-</c:if>
-
-    <tr valign="top">
-        <td class="formlabel" align="left"><span class="addNewStudyLayout"><fmt:message key="SED_2" bundle="${resword}"/></span>&nbsp;<small class="required">*</small></td>
-        <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
-                <tr><td>
-                    <div class="selectS">
-                        <select name="studyEventDefinition" class="formfieldM">
-                            <option value="">-<fmt:message key="select" bundle="${resword}"/>-</option>
-                            <c:forEach var="event" items="${allDefsArray}">
-                                <option <c:if test="${studyEventDefinition == event.id}">SELECTED</c:if> value="<c:out value="${event.id}"/>"><c:out value="${event.name}" />
-                                </option>
-                            </c:forEach>
-                        </select>
-                    </div>
+                        <table border="0" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td valign="top"><div class="formfieldXL_BG">
+                                    <input class="form-control" onfocus="this.select()" type="text" name="uniqueIdentifier" value="<c:out value="${uniqueIdentifier}"/>" width="30" class="formfieldXL">
+                                </div></td>
+                                <td>&nbsp;</td>
+                            </tr>
+                            <tr>
+                                <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="uniqueIdentifier"/></jsp:include></td>
+                            </tr>
+                        </table>
                     </td>
                 </tr>
-                
+                </c:when>
+                <c:otherwise>
+                  <input type="hidden" name="uniqueIdentifier" value="<c:out value="${uniqueIdentifier}"/>">
+                </c:otherwise>
+                </c:choose>
 
-            </table>
-        </td>
-    </tr>
-    <tr>
-        <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="studyEventDefinition"/></jsp:include></td>
-    </tr>
+                <tr valign="top" >
 
-    <tr valign="top">
-        <td class="formlabel" align="left">
-            <span class="addNewStudyLayout"><fmt:message key="start_date" bundle="${resword}"/></span>&nbsp;<small class="required">*</small>
-        </td>
-        <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
-                <tr>
+                    <td class="formlabel" align="left">
+                        <span class="addNewStudyLayout"><fmt:message key="enrollment_date" bundle="${resword}"/></span>&nbsp;<small class="required">*</small>
+                    </td>
                     <td valign="top">
-                         <a href="#">
-
-                             <span class="icon icon-calendarGB" alt="<fmt:message key="show_calendar" bundle="${resword}"/>" title="<fmt:message key="show_calendar" bundle="${resword}"/>" border="0" id="enrollmentDateTrigger2"/></a>
-                             <script type="text/javascript">
-                             Calendar.setup({inputField  : "enrollmentDateField2", ifFormat    : "<fmt:message key="date_format_calender" bundle="${resformat}"/>", button      : "enrollmentDateTrigger2" ,customPX: 300, customPY: 10 });
-                             </script>
+                        <table border="0" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td valign="top">
+                                    <a href="#">
+                                         <span class="icon icon-calendarGB" alt="<fmt:message key="show_calendar" bundle="${resword}"/>" title="<fmt:message key="show_calendar" bundle="${resword}"/>" border="0" id="enrollmentDateTrigger" />
+                                            <script type="text/javascript">
+                                            Calendar.setup({inputField  : "enrollmentDateField", ifFormat    : "<fmt:message key="date_format_calender" bundle="${resformat}"/>", button      : "enrollmentDateTrigger", customPX: 300, customPY: 10 });
+                                            </script>
+                                        </a>
+                                            
+                                </td>
+                                <td>
+                                    <input class="form-control" onfocus="this.select()" type="text" name="enrollmentDate" size="16" value="<c:out value="${enrollmentDate}" />" class="formfieldM" id="enrollmentDateField" />
+                                </td>
+                            </tr>
+                           
+                        </table>
                     </td>
-                    <td>
-                        <input class="form-control" type="text" name="startDate" size="15" value="<c:out value="${startDate}" />" class="formfieldM" id="enrollmentDateField2" />
+                </tr>
+                 <tr>
+                                <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="enrollmentDate"/></jsp:include></td>
+                            </tr>
+
+                <tr valign="top">
+                    <c:if test="${study.studyParameterConfig.genderRequired !='not used'}">
+                    <td class="formlabel" align="left">
+                        <span class="addNewStudyLayout"><fmt:message key="gender" bundle="${resword}"/></span>
+                        <c:choose>
+                            <c:when test="${study.studyParameterConfig.genderRequired !='false'}">
+                               &nbsp;<small class="required">*</small>
+                            </c:when>
+                        </c:choose>
+                    </td>
+                    <td valign="top">
+                        <table border="0" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td valign="top"><div class="selectS">
+                                    <select name="gender">
+                                        <option value="">-<fmt:message key="select" bundle="${resword}"/>-</option>
+                                        <c:choose>
+                                            <c:when test="${!empty chosenGender}">
+                                                <c:choose>
+                                                    <c:when test='${chosenGender == "m"}'>
+                                                        <option value="m" selected><fmt:message key="male" bundle="${resword}"/></option>
+                                                        <option value="f"><fmt:message key="female" bundle="${resword}"/></option>
+                                                    </c:when>
+                                                    <c:otherwise>
+                                                        <option value="m"><fmt:message key="male" bundle="${resword}"/></option>
+                                                        <option value="f" selected><fmt:message key="female" bundle="${resword}"/></option>
+                                                    </c:otherwise>
+                                                </c:choose>
+                                            </c:when>
+                                            <c:otherwise>
+                                                <option value="m"><fmt:message key="male" bundle="${resword}"/></option>
+                                                <option value="f"><fmt:message key="female" bundle="${resword}"/></option>
+                                            </c:otherwise>
+                                        </c:choose>
+                                        </select></div>
+                            </td>
+                </tr>
+                </table>
+                    </td>
+                </c:if>
+                </tr>
+                <tr>
+                    <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="gender"/></jsp:include></td>
+                </tr>
+
+
+                <c:choose>
+                <c:when test="${study.studyParameterConfig.collectDob == '1'}">
+                <tr valign="top">
+                    <td class="formlabel" align="left"><span class="addNewStudyLayout"><fmt:message key="date_of_birth" bundle="${resword}"/></span>&nbsp;<small class="required">*</small></td>
+                    <td valign="top">
+                        <table border="0" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td valign="top">
+                                    <a href="#">
+                                        <span class="icon icon-calendarGB" alt="<fmt:message key="show_calendar" bundle="${resword}"/>" title="<fmt:message key="show_calendar" bundle="${resword}"/>" border="0" id="dobTrigger" />
+                                        <script type="text/javascript">
+                                        Calendar.setup({inputField  : "dobField", ifFormat    : "<fmt:message key="date_format_calender" bundle="${resformat}"/>", button      : "dobTrigger", customPX: 300, customPY: 10 });
+                                        </script>
+                                    </a>    
+                                </td>
+                                <td>
+                                    <input onfocus="this.select()" type="text" name="dob" size="16" value="<c:out value="${dob}" />" class="formfieldM form-control" id="dobField" />
+                                </td>
+                            </tr>
+                        </table>
                     </td>
                 </tr>
-            </table>
-        </td>
-    </tr>
-       <tr>
-        <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="startDate"/></jsp:include></td>
-        </tr>
-    <c:choose>
-    <c:when test="${study.studyParameterConfig.eventLocationRequired == 'required'}">
-    <tr valign="top">
-        <td class="formlabel"><fmt:message key="location" bundle="${resword}"/>:</td>
-        <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
                 <tr>
-                    <td valign="top"><div class="formfieldXL_BG">
-                       <input type="text" name="location"size="50" value="<c:out value="${location}"/>" class="formfieldXL">
-                    </div></td>
-                    <td>&nbsp;*</td>
+                    <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="dob"/></jsp:include></td>
                 </tr>
-            </table>
-        </td>
-    </tr>
-    <tr>
-        <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="location"/></jsp:include></td>
-    </tr>
 
-    </c:when>
-    <c:when test="${study.studyParameterConfig.eventLocationRequired == 'optional'}">
-    <tr valign="top">
-        <td class="formlabel"><fmt:message key="location" bundle="${resword}"/>:</td>
-        <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
-                <tr>
-                    <td valign="top"><div class="formfieldXL_BG">
-                       <input type="text" name="location"size="50" class="formfieldXL">
-                    </div></td>
-                    <td>&nbsp;</td>
+                </c:when>
+                <c:when test="${study.studyParameterConfig.collectDob == '2'}">
+                <tr valign="top">
+                    <td class="formlabel" align="left"><span class="addNewStudyLayout"><fmt:message key="year_of_birth" bundle="${resword}"/></span>&nbsp;<small class="required">*</small></td>
+                    <td valign="top">
+                        <table border="0" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td valign="top"><div class="formfieldM_BG">
+                                    <input onfocus="this.select()" type="text" name="yob" size="15" value="<c:out value="${yob}" />" class="formfieldM form-control" />
+                                </td>
+                                <td class="formlabel" align="left">(<fmt:message key="date_format_year" bundle="${resformat}"/>)</td>
+                            </tr>
+                        </table>
+                    </td>
                 </tr>
+                <tr>
+                    <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="yob"/></jsp:include></td>
+                </tr>
+
+              </c:when>
+              <c:otherwise>
+                <input type="hidden" name="dob" value="" />
+              </c:otherwise>
+             </c:choose>
+            <c:if test="${(!empty studyGroupClasses)}">
+                <tr valign="top">
+                  <td class="formlabel" align="right"><fmt:message key="subject_group_class" bundle="${resword}"/>:
+                  <td class="table_cell">
+                  <c:set var="count" value="0"/>
+                  <table border="0" cellpadding="0">
+                    <c:forEach var="group" items="${studyGroupClasses}">
+                    <tr valign="top">
+                     <td><b><c:out value="${group.name}"/></b></td>
+                     <td><div class="formfieldM_BG">
+                         <select name="studyGroupId<c:out value="${count}"/>" class="formfieldM">
+                             <option value=""><c:out value="${group.name}"/>:</option>
+                              <c:forEach var="studyGroup" items="${group.studyGroups}">
+                                <option value="<c:out value="${studyGroup.id}"/>"><c:out value="${studyGroup.name}"/></option>
+                              </c:forEach>
+                          </select></div>
+                         <c:import url="../showMessage.jsp"><c:param name="key" value="studyGroupId${count}" /></c:import>
+
+                          </td>
+                          <c:if test="${group.subjectAssignment=='Required'}">
+                            <td align="left">&nbsp;*</td>
+                          </c:if>
+                          </tr>
+                         <c:set var="count" value="${count+1}"/>
+                    </c:forEach>
+                    </table>
+                  </td>
+                </tr>
+            </c:if>
+
+                <tr valign="top">
+                    <td class="formlabel" align="left"><span class="addNewStudyLayout"><fmt:message key="SED_2" bundle="${resword}"/></span>&nbsp;<small class="required">*</small></td>
+                    <td valign="top">
+                        <table border="0" cellpadding="0" cellspacing="0">
+                            <tr><td>
+                                <div class="selectS">
+                                    <select name="studyEventDefinition" class="formfieldM">
+                                        <option value="">-<fmt:message key="select" bundle="${resword}"/>-</option>
+                                        <c:forEach var="event" items="${allDefsArray}">
+                                            <option <c:if test="${studyEventDefinition == event.id}">SELECTED</c:if> value="<c:out value="${event.id}"/>"><c:out value="${event.name}" />
+                                            </option>
+                                        </c:forEach>
+                                    </select>
+                                </div>
+                                </td>
+                            </tr>
+                            
+
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="studyEventDefinition"/></jsp:include></td>
+                </tr>
+
+                <tr valign="top">
+                    <td class="formlabel" align="left">
+                        <span class="addNewStudyLayout"><fmt:message key="start_date" bundle="${resword}"/></span>&nbsp;<small class="required">*</small>
+                    </td>
+                    <td valign="top">
+                        <table border="0" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td valign="top">
+                                     <a href="#">
+
+                                         <span class="icon icon-calendarGB" alt="<fmt:message key="show_calendar" bundle="${resword}"/>" title="<fmt:message key="show_calendar" bundle="${resword}"/>" border="0" id="enrollmentDateTrigger2"/></a>
+                                         <script type="text/javascript">
+                                         Calendar.setup({inputField  : "enrollmentDateField2", ifFormat    : "<fmt:message key="date_format_calender" bundle="${resformat}"/>", button      : "enrollmentDateTrigger2" ,customPX: 300, customPY: 10 });
+                                         </script>
+                                </td>
+                                <td>
+                                    <input class="form-control" type="text" name="startDate" size="15" value="<c:out value="${startDate}" />" class="formfieldM" id="enrollmentDateField2" />
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                   <tr>
+                    <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="startDate"/></jsp:include></td>
+                    </tr>
+                <c:choose>
+                <c:when test="${study.studyParameterConfig.eventLocationRequired == 'required'}">
+                <tr valign="top">
+                    <td class="formlabel"><fmt:message key="location" bundle="${resword}"/>:</td>
+                    <td valign="top">
+                        <table border="0" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td valign="top"><div class="formfieldXL_BG">
+                                   <input type="text" name="location"size="50" value="<c:out value="${location}"/>" class="formfieldXL">
+                                </div></td>
+                                <td>&nbsp;*</td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="location"/></jsp:include></td>
+                </tr>
+
+                </c:when>
+                <c:when test="${study.studyParameterConfig.eventLocationRequired == 'optional'}">
+                <tr valign="top">
+                    <td class="formlabel"><fmt:message key="location" bundle="${resword}"/>:</td>
+                    <td valign="top">
+                        <table border="0" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td valign="top"><div class="formfieldXL_BG">
+                                   <input type="text" name="location"size="50" class="formfieldXL">
+                                </div></td>
+                                <td>&nbsp;</td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                </c:when>
+                <c:otherwise>
+                    <input type="hidden" name="location" value=""/>
+                </c:otherwise>
+                </c:choose>
             </table>
+            </div>
         </td>
     </tr>
-    </c:when>
-    <c:otherwise>
-        <input type="hidden" name="location" value=""/>
-    </c:otherwise>
-    </c:choose>
     <tr>
         <td><div class="lines"></div></td>
-        <td><div class="lines"></div></td>
     </tr>
     <tr>
-        <td></td>
         <td colspan="2">
             <input type="submit" name="addSubject" value="Add"/>
             &nbsp;
@@ -436,7 +440,5 @@
     </tr>
 
 </table>
-
-</div>
 
 </form>

--- a/web/src/main/webapp/WEB-INF/jsp/submit/addNewSubjectExpressNew.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/addNewSubjectExpressNew.jsp
@@ -207,7 +207,14 @@
 
     <tr valign="top">
         <c:if test="${study.studyParameterConfig.genderRequired !='not used'}">
-        <td class="formlabel" align="left"><span class="addNewStudyLayout"><fmt:message key="gender" bundle="${resword}"/></span></td>
+        <td class="formlabel" align="left">
+            <span class="addNewStudyLayout"><fmt:message key="gender" bundle="${resword}"/></span>
+            <c:choose>
+                <c:when test="${study.studyParameterConfig.genderRequired !='false'}">
+                   &nbsp;<small class="required">*</small>
+                </c:when>
+            </c:choose>
+        </td>
         <td valign="top">
             <table border="0" cellpadding="0" cellspacing="0">
                 <tr>
@@ -234,13 +241,6 @@
                             </c:choose>
                             </select></div>
                 </td>
-    <td align="left">
-        <c:choose>
-        <c:when test="${study.studyParameterConfig.genderRequired !='false'}">
-           <span class="formlabel">&nbsp;*</span>
-        </c:when>
-        </c:choose>
-    </td>
     </tr>
     </table>
         </td>
@@ -254,24 +254,21 @@
     <c:choose>
     <c:when test="${study.studyParameterConfig.collectDob == '1'}">
     <tr valign="top">
-        <td class="formlabel" align="right"><fmt:message key="date_of_birth" bundle="${resword}"/></td>
+        <td class="formlabel" align="left"><span class="addNewStudyLayout"><fmt:message key="date_of_birth" bundle="${resword}"/></span>&nbsp;<small class="required">*</small></td>
         <td valign="top">
             <table border="0" cellpadding="0" cellspacing="0">
                 <tr>
-                    <td valign="top"><div class="formfieldM_BG">
-                        <input onfocus="this.select()" type="text" name="dob" size="16" value="<c:out value="${dob}" />" class="formfieldM" id="dobField" />
-                         <a href="#">
-                            <span class="icon icon-calendar" alt="<fmt:message key="show_calendar" bundle="${resword}"/>" title="<fmt:message key="show_calendar" bundle="${resword}"/>" border="0" id="dobTrigger" />
+                    <td valign="top">
+                        <a href="#">
+                            <span class="icon icon-calendarGB" alt="<fmt:message key="show_calendar" bundle="${resword}"/>" title="<fmt:message key="show_calendar" bundle="${resword}"/>" border="0" id="dobTrigger" />
                             <script type="text/javascript">
                             Calendar.setup({inputField  : "dobField", ifFormat    : "<fmt:message key="date_format_calender" bundle="${resformat}"/>", button      : "dobTrigger", customPX: 300, customPY: 10 });
                             </script>
-                        </a>
-                        *
+                        </a>    
                     </td>
                     <td>
-                   
+                        <input onfocus="this.select()" type="text" name="dob" size="16" value="<c:out value="${dob}" />" class="formfieldM form-control" id="dobField" />
                     </td>
-                    
                 </tr>
             </table>
         </td>
@@ -283,7 +280,7 @@
     </c:when>
     <c:when test="${study.studyParameterConfig.collectDob == '2'}">
     <tr valign="top">
-        <td class="formlabel" align="right"><fmt:message key="year_of_birth" bundle="${resword}"/></td>
+        <td class="formlabel" align="left"><span class="addNewStudyLayout"><fmt:message key="year_of_birth" bundle="${resword}"/></span></td>
         <td valign="top">
             <table border="0" cellpadding="0" cellspacing="0">
                 <tr>

--- a/web/src/main/webapp/WEB-INF/jsp/submit/addNewSubjectExpressNew.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/addNewSubjectExpressNew.jsp
@@ -91,7 +91,7 @@
                         <input class="form-control" type="hidden" name="addWithEvent" value="1"/><span class="addNewStudyLayout">
                         <fmt:message key="study_subject_ID" bundle="${resword}"/></span>&nbsp;<small class="required">*</small></td>
                     <td valign="top">
-                        <table border="0" cellpadding="0" cellspacing="0">
+                        <table border="0" cellpadding="0" cellspacing="0" class="full-width">
                             <tr>
                                 <td valign="top"><div class="formfieldXL_BG">
                                 <c:choose>
@@ -119,12 +119,11 @@
                         <span class="addNewStudyLayout"><fmt:message key="secondary_ID" bundle="${resword}"/></span>
                     </td>
                     <td valign="top">
-                        <table border="0" cellpadding="0" cellspacing="0">
+                        <table border="0" cellpadding="0" cellspacing="0" class="full-width">
                             <tr>        
                                 <td valign="top"><div class="formfieldXL_BG">
                                     <input class="form-control" onfocus="this.select()" type="text" name="secondaryLabel" value="<c:out value="${secondaryLabel}"/>" width="30" class="formfieldXL">
                                 </div></td>
-                                <td>&nbsp;</td>
                             </tr>
                             <tr>        
                                 <td><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="secondaryLabel"/></jsp:include></td>        
@@ -141,14 +140,15 @@
                         <span class="addNewStudyLayout"><fmt:message key="person_ID" bundle="${resword}"/></span>&nbsp;<small class="required">*</small>
                     </td>
                     <td valign="top">
-                        <table border="0" cellpadding="0" cellspacing="0">
+                        <table border="0" cellpadding="0" cellspacing="0" class="full-width">
                             <tr>
                                 <td valign="top"><div class="formfieldXL_BG">
                                     <input class="form-control" onfocus="this.select()" type="text" name="uniqueIdentifier" value="<c:out value="${uniqueIdentifier}"/>" width="30" class="formfieldXL">
                                 </div></td>
-                                <td>&nbsp;</td>
                             </tr>
-                            <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="uniqueIdentifier"/></jsp:include></td>
+                            <tr>
+                                <td><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="uniqueIdentifier"/></jsp:include></td>
+                            </tr>
                         </table>
                     </td>
                 </tr>
@@ -159,15 +159,14 @@
                         <span class="addNewStudyLayout"><fmt:message key="person_ID" bundle="${resword}"/></span>
                     </td>
                     <td valign="top">
-                        <table border="0" cellpadding="0" cellspacing="0">
+                        <table border="0" cellpadding="0" cellspacing="0" class="full-width">
                             <tr>
                                 <td valign="top"><div class="formfieldXL_BG">
                                     <input class="form-control" onfocus="this.select()" type="text" name="uniqueIdentifier" value="<c:out value="${uniqueIdentifier}"/>" width="30" class="formfieldXL">
                                 </div></td>
-                                <td>&nbsp;</td>
                             </tr>
                             <tr>
-                                <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="uniqueIdentifier"/></jsp:include></td>
+                                <td><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="uniqueIdentifier"/></jsp:include></td>
                             </tr>
                         </table>
                     </td>
@@ -184,9 +183,9 @@
                         <span class="addNewStudyLayout"><fmt:message key="enrollment_date" bundle="${resword}"/></span>&nbsp;<small class="required">*</small>
                     </td>
                     <td valign="top">
-                        <table border="0" cellpadding="0" cellspacing="0">
+                        <table border="0" cellpadding="0" cellspacing="0" class="full-width">
                             <tr>
-                                <td valign="top">
+                                <td valign="top" class="icon-container" class="icon-container">
                                     <a href="#">
                                          <span class="icon icon-calendarGB" alt="<fmt:message key="show_calendar" bundle="${resword}"/>" title="<fmt:message key="show_calendar" bundle="${resword}"/>" border="0" id="enrollmentDateTrigger" />
                                             <script type="text/javascript">
@@ -195,17 +194,16 @@
                                         </a>
                                             
                                 </td>
-                                <td>
+                                <td class="icon-input-container">
                                     <input class="form-control" onfocus="this.select()" type="text" name="enrollmentDate" size="16" value="<c:out value="${enrollmentDate}" />" class="formfieldM" id="enrollmentDateField" />
                                 </td>
                             </tr>
-                           
+                            <tr>
+                                <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="enrollmentDate"/></jsp:include></td>
+                            </tr>
                         </table>
                     </td>
                 </tr>
-                 <tr>
-                                <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="enrollmentDate"/></jsp:include></td>
-                            </tr>
 
                 <tr valign="top">
                     <c:if test="${study.studyParameterConfig.genderRequired !='not used'}">
@@ -242,14 +240,14 @@
                                             </c:otherwise>
                                         </c:choose>
                                         </select></div>
-                            </td>
-                </tr>
-                </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="gender"/></jsp:include></td>
+                            </tr>
+                        </table>
                     </td>
                 </c:if>
-                </tr>
-                <tr>
-                    <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="gender"/></jsp:include></td>
                 </tr>
 
 
@@ -258,9 +256,9 @@
                 <tr valign="top">
                     <td class="formlabel" align="left"><span class="addNewStudyLayout"><fmt:message key="date_of_birth" bundle="${resword}"/></span>&nbsp;<small class="required">*</small></td>
                     <td valign="top">
-                        <table border="0" cellpadding="0" cellspacing="0">
+                        <table border="0" cellpadding="0" cellspacing="0" class="full-width">
                             <tr>
-                                <td valign="top">
+                                <td valign="top" class="icon-container">
                                     <a href="#">
                                         <span class="icon icon-calendarGB" alt="<fmt:message key="show_calendar" bundle="${resword}"/>" title="<fmt:message key="show_calendar" bundle="${resword}"/>" border="0" id="dobTrigger" />
                                         <script type="text/javascript">
@@ -268,15 +266,15 @@
                                         </script>
                                     </a>    
                                 </td>
-                                <td>
+                                <td class="icon-input-container">
                                     <input onfocus="this.select()" type="text" name="dob" size="16" value="<c:out value="${dob}" />" class="formfieldM form-control" id="dobField" />
                                 </td>
                             </tr>
+                            <tr>
+                                <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="dob"/></jsp:include></td>
+                            </tr>
                         </table>
                     </td>
-                </tr>
-                <tr>
-                    <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="dob"/></jsp:include></td>
                 </tr>
 
                 </c:when>
@@ -284,18 +282,18 @@
                 <tr valign="top">
                     <td class="formlabel" align="left"><span class="addNewStudyLayout"><fmt:message key="year_of_birth" bundle="${resword}"/></span>&nbsp;<small class="required">*</small></td>
                     <td valign="top">
-                        <table border="0" cellpadding="0" cellspacing="0">
+                        <table border="0" cellpadding="0" cellspacing="0" class="full-width">
                             <tr>
                                 <td valign="top"><div class="formfieldM_BG">
                                     <input onfocus="this.select()" type="text" name="yob" size="15" value="<c:out value="${yob}" />" class="formfieldM form-control" />
                                 </td>
                                 <td class="formlabel" align="left">(<fmt:message key="date_format_year" bundle="${resformat}"/>)</td>
                             </tr>
+                            <tr>
+                                <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="yob"/></jsp:include></td>
+                            </tr>
                         </table>
                     </td>
-                </tr>
-                <tr>
-                    <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="yob"/></jsp:include></td>
                 </tr>
 
               </c:when>
@@ -305,7 +303,7 @@
              </c:choose>
             <c:if test="${(!empty studyGroupClasses)}">
                 <tr valign="top">
-                  <td class="formlabel" align="right"><fmt:message key="subject_group_class" bundle="${resword}"/>:
+                  <td class="formlabel" align="left"><span class="addNewStudyLayout"><fmt:message key="subject_group_class" bundle="${resword}"/></span>
                   <td class="table_cell">
                   <c:set var="count" value="0"/>
                   <table border="0" cellpadding="0">
@@ -349,13 +347,11 @@
                                 </div>
                                 </td>
                             </tr>
-                            
-
+                            <tr>
+                                <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="studyEventDefinition"/></jsp:include></td>
+                            </tr>
                         </table>
                     </td>
-                </tr>
-                <tr>
-                    <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="studyEventDefinition"/></jsp:include></td>
                 </tr>
 
                 <tr valign="top">
@@ -363,9 +359,9 @@
                         <span class="addNewStudyLayout"><fmt:message key="start_date" bundle="${resword}"/></span>&nbsp;<small class="required">*</small>
                     </td>
                     <td valign="top">
-                        <table border="0" cellpadding="0" cellspacing="0">
+                        <table border="0" cellpadding="0" cellspacing="0" class="full-width">
                             <tr>
-                                <td valign="top">
+                                <td valign="top" class="icon-container">
                                      <a href="#">
 
                                          <span class="icon icon-calendarGB" alt="<fmt:message key="show_calendar" bundle="${resword}"/>" title="<fmt:message key="show_calendar" bundle="${resword}"/>" border="0" id="enrollmentDateTrigger2"/></a>
@@ -373,46 +369,49 @@
                                          Calendar.setup({inputField  : "enrollmentDateField2", ifFormat    : "<fmt:message key="date_format_calender" bundle="${resformat}"/>", button      : "enrollmentDateTrigger2" ,customPX: 300, customPY: 10 });
                                          </script>
                                 </td>
-                                <td>
+                                <td class="icon-input-container">
                                     <input class="form-control" type="text" name="startDate" size="15" value="<c:out value="${startDate}" />" class="formfieldM" id="enrollmentDateField2" />
                                 </td>
                             </tr>
-                        </table>
-                    </td>
-                </tr>
-                   <tr>
-                    <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="startDate"/></jsp:include></td>
-                    </tr>
-                <c:choose>
-                <c:when test="${study.studyParameterConfig.eventLocationRequired == 'required'}">
-                <tr valign="top">
-                    <td class="formlabel"><fmt:message key="location" bundle="${resword}"/>:</td>
-                    <td valign="top">
-                        <table border="0" cellpadding="0" cellspacing="0">
                             <tr>
-                                <td valign="top"><div class="formfieldXL_BG">
-                                   <input type="text" name="location"size="50" value="<c:out value="${location}"/>" class="formfieldXL">
-                                </div></td>
-                                <td>&nbsp;*</td>
+                                <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="startDate"/></jsp:include></td>
                             </tr>
                         </table>
                     </td>
                 </tr>
-                <tr>
-                    <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="location"/></jsp:include></td>
+                
+                <c:choose>
+                <c:when test="${study.studyParameterConfig.eventLocationRequired == 'required'}">
+                <tr valign="top">
+                    <td class="formlabel" align="left">
+                        <span class="addNewStudyLayout"><fmt:message key="location" bundle="${resword}"/></span>&nbsp;<small class="required">*</small>
+                    </td>
+                    <td valign="top">
+                        <table border="0" cellpadding="0" cellspacing="0" class="full-width">
+                            <tr>
+                                <td valign="top"><div class="formfieldXL_BG">
+                                   <input type="text" name="location"size="50" value="<c:out value="${location}"/>" class="formfieldXL form-control">
+                                </div></td>
+                            </tr>
+                            <tr>
+                                <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="location"/></jsp:include></td>
+                            </tr>
+                        </table>
+                    </td>
                 </tr>
 
                 </c:when>
                 <c:when test="${study.studyParameterConfig.eventLocationRequired == 'optional'}">
                 <tr valign="top">
-                    <td class="formlabel"><fmt:message key="location" bundle="${resword}"/>:</td>
+                    <td class="formlabel" align="left">
+                        <span class="addNewStudyLayout"><fmt:message key="location" bundle="${resword}"/></span>
+                    </td>
                     <td valign="top">
-                        <table border="0" cellpadding="0" cellspacing="0">
+                        <table border="0" cellpadding="0" cellspacing="0" class="full-width">
                             <tr>
                                 <td valign="top"><div class="formfieldXL_BG">
-                                   <input type="text" name="location"size="50" class="formfieldXL">
+                                   <input type="text" name="location"size="50" class="formfieldXL form-control">
                                 </div></td>
-                                <td>&nbsp;</td>
                             </tr>
                         </table>
                     </td>
@@ -422,6 +421,7 @@
                     <input type="hidden" name="location" value=""/>
                 </c:otherwise>
                 </c:choose>
+                
             </table>
             </div>
         </td>

--- a/web/src/main/webapp/includes/styles.css
+++ b/web/src/main/webapp/includes/styles.css
@@ -833,5 +833,4 @@ div#subjectSDV table#sdv {
     justify-content: flex-end;
     padding-top: 15px;
     border-top: 1px solid #eceeef;
-    width: 197px;
 }

--- a/web/src/main/webapp/includes/styles.css
+++ b/web/src/main/webapp/includes/styles.css
@@ -834,3 +834,30 @@ div#subjectSDV table#sdv {
     padding-top: 15px;
     border-top: 1px solid #eceeef;
 }
+
+.alert.small {
+  line-height: 3px;
+  margin-bottom: 10px;
+  font-size: small;
+  text-align: left;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.full-width tr {
+  text-align: left;
+}
+
+.full-width td.icon-container {
+  width: 32px;
+}
+
+.full-width td.icon-input-container input {
+  height: 32px;
+  border-left: none;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  margin-left: -2px;
+}


### PR DESCRIPTION
- For Bridge search boxes, change the default text to be blank (instead of “Study Subject ID”). For the top left header subject search box only, make the default text be “Study Subject ID”. Specifically, the following search boxes should be blank by default:
1. Tasks > CRFs
![screenshot from 2017-10-06 19-48-31](https://user-images.githubusercontent.com/13865076/31276889-d43c3172-aad0-11e7-8871-fe78493ddf55.png)

2. Tasks > Sites
![screenshot from 2017-10-06 19-48-59](https://user-images.githubusercontent.com/13865076/31276894-dd8a4ef8-aad0-11e7-892d-43346cc3f6d1.png)

3. Tasks > View Events
![screenshot from 2017-10-06 19-50-51](https://user-images.githubusercontent.com/13865076/31276900-e2fe1f4a-aad0-11e7-8b10-f8537132921c.png)

4. Tasks > View Datasets
![screenshot from 2017-10-06 19-52-37](https://user-images.githubusercontent.com/13865076/31276901-e91dbda4-aad0-11e7-96d1-786a7a6e1217.png)

5. Subject Matrix > View a subject 
![screenshot from 2017-10-06 19-48-02](https://user-images.githubusercontent.com/13865076/31276912-f46aebfa-aad0-11e7-8d14-599bdb07abf7.png)


- When optional fields are enabled for a study, the Add New Subject Window has a couple issues:
1. The labels for the optional fields (Person ID & Date of Birth) do not match the standard fields (see below).
2. If Date of Birth, Sex, or Person ID is configured to be required, those fields should have the same required style asterisk (*) as the other required fields. Make the asterisks red and put them right after the field labels.
3. The window is not big enough to fit all of the optional fields (Person ID and Date of Birth) and the Add/Cancel buttons - some content/buttons gets pushed out of the window.  It is worse if any error messages are displayed (for example, submit the form with no data entered so that required field error messages are shown). To resolve this, make the window wide enough to fit all fields and all buttons. Make the window scale vertically so that all of the fields, buttons, and error messages fit.  Make sure to test with Person ID = Always, Sex = Always, and Date of Birth = Always and Date of Birth = Only the Year. Also test after submitting the form with missing or invalid values so that error messages appear.
![screenshot from 2017-10-06 20-05-13](https://user-images.githubusercontent.com/13865076/31277070-ba288942-aad1-11e7-91c7-ba611ea82c20.png)

![screenshot from 2017-10-06 19-54-55](https://user-images.githubusercontent.com/13865076/31277079-c3b02696-aad1-11e7-8aad-3fafb17503fb.png)

Note: Update alert messages commit in another PR 