### PR TITLE
OC cosmetic bridge

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/control/form/Validator.java
+++ b/web/src/main/java/org/akaza/openclinica/control/form/Validator.java
@@ -774,7 +774,16 @@ public class Validator {
             case COMPARES_TO_STATIC_VALUE:
                 NumericComparisonOperator operator = (NumericComparisonOperator) v.getArg(0);
                 float compareTo = v.getFloat(1);
-                errorMessage = resexception.getString("input_provided_is_not_year");
+                int compareToInt = new Float(compareTo).intValue();
+                Calendar cal = Calendar.getInstance();
+                cal.setTime(new Date());
+                if (compareToInt == 1000 && operator.getDescription().equals("greater than or equal")) {
+                    errorMessage = resexception.getString("year_must_be") + " " + resword.getString("greater_than") + " " + compareToInt + ".";
+                } else if (compareToInt == cal.get(Calendar.YEAR) && operator.getDescription().equals("less than or equal to")) {
+                    errorMessage = resexception.getString("date_provided_not_past");
+                } else {
+                    errorMessage = resexception.getString("input_provided_is_not") + operator.getDescription() + " " + new Float(compareTo).intValue() + ".";
+                }
                 break;
             case LENGTH_NUMERIC_COMPARISON:
                 NumericComparisonOperator operator2 = (NumericComparisonOperator) v.getArg(0);

--- a/web/src/main/java/org/akaza/openclinica/control/submit/AddNewSubjectServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/AddNewSubjectServlet.java
@@ -450,10 +450,10 @@ public class AddNewSubjectServlet extends SecureController {
                 if (!existingSubShown) {
                     Object isSubjectOverlay = fp.getRequest().getParameter("subjectOverlay");
                     if (isSubjectOverlay != null){
-                        int eventId = fp.getInt("studyEventDefinition");
-                        if (eventId < 1) {
-                             Validator.addError(errors, STUDY_EVENT_DEFINITION, resexception.getString("input_not_acceptable_option"));
-                        }
+                        // int eventId = fp.getInt("studyEventDefinition");
+                        // if (eventId < 1) {
+                        //      Validator.addError(errors, STUDY_EVENT_DEFINITION, resexception.getString("input_not_acceptable_option"));
+                        // }
                         String location = fp.getString(LOCATION);
                         if (location == null && location.length() == 0) {
                             Validator.addError(errors, LOCATION, resexception.getString("field_not_blank"));

--- a/web/src/main/java/org/akaza/openclinica/control/submit/ListStudySubjectTableFactory.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ListStudySubjectTableFactory.java
@@ -1003,7 +1003,7 @@ public class ListStudySubjectTableFactory extends AbstractTableFactory {
             eventDiv.td(0).styleClass(tableHeaderRowStyleClass).colspan("2").close();
             eventDiv.bold().append(occurrence_x_of).append(" " + (i + 1) + " of " + studyEventsSize).br();
             eventDiv.append(formatDate(studyEventBean.getDateStarted())).br();
-            eventDiv.append(status + ": " + studyEventBean.getSubjectEventStatus().getName());
+            eventDiv.append(studyEventBean.getSubjectEventStatus().getName());
             eventDiv.boldEnd().tdEnd().trEnd(0);
             // <tr><td><table>...</table></td></tr>
             eventDiv.tr(0).id("Menu_on_" + studySubjectLabel + "_" + sed.getId() + "_" + rowCount + "_" + (i + 1)).style("display: none").close();
@@ -1143,7 +1143,7 @@ public class ListStudySubjectTableFactory extends AbstractTableFactory {
         eventDiv.append(eventText).append(": ").append(sed.getName()).br();
 
         if (!sed.isRepeating()) {
-            eventDiv.br().bold().append(resword.getString("status")).append(": ").append(eventStatus.getName()).br();
+            eventDiv.br().bold().append(eventStatus.getName()).br();
             eventDiv.tdEnd();
             eventDiv.td(0).styleClass(tableHeaderRowLeftStyleClass).align("right").close();
             linkBuilder(eventDiv, studySubjectLabel, rowCount, studyEvents, sed);
@@ -1160,9 +1160,9 @@ public class ListStudySubjectTableFactory extends AbstractTableFactory {
             eventDiv.bold().append(occurrence_x_of).append(" 1 of 1").br();
             if (studyEvents.size() > 0) {
                 eventDiv.append(formatDate(studyEvents.get(0).getDateStarted())).br();
-                eventDiv.append(status + " : " + studyEvents.get(0).getSubjectEventStatus().getName());
+                eventDiv.append(studyEvents.get(0).getSubjectEventStatus().getName());
             } else {
-                eventDiv.append(status + " : " + SubjectEventStatus.NOT_SCHEDULED.getName());
+                eventDiv.append(SubjectEventStatus.NOT_SCHEDULED.getName());
             }
             eventDiv.boldEnd().tdEnd().trEnd(0);
             if (eventStatus != SubjectEventStatus.NOT_SCHEDULED && eventSysStatus != Status.DELETED && eventSysStatus != Status.AUTO_DELETED) {

--- a/web/src/main/resources/org/akaza/openclinica/i18n/exceptions.properties
+++ b/web/src/main/resources/org/akaza/openclinica/i18n/exceptions.properties
@@ -18,8 +18,6 @@ anwer_not_match = Your answers for this value did not match.  Please provide ans
 
 argument = argument
 
-input_provided_is_not_year = Date must not be in the future.
-
 begin_data_entry_without_event_but_CRF = You are trying to begin data entry for a CRF within a Study Event, but the specified CRF version does not exist.
 
 begin_data_entry_without_event_but_especified_event = You are trying to begin data entry for a CRF within a Study Event, but the specified study event definition does not exist within the study.
@@ -112,7 +110,7 @@ input_not_valid_phone = The input you provided is not a valid phone number in\t
 
 input_not_valid_username = The input you provided is not a valid user name in\t
 
-input_provided_is_not = Year must be\t
+input_provided_is_not = The input you provided is not\t
 
 input_provided_not_precede = The input you provided does not precede\t
 
@@ -327,6 +325,8 @@ will_be_changed_if_you_continue = will be changed if you continue. If you think 
 will_not_be_changed_if = will not be changed if the item has data already.
 
 wrong_old_password = Wrong old password.
+
+year_must_be = Year must be 
 
 you_are_trying_to = You are trying to
 

--- a/web/src/main/resources/org/akaza/openclinica/i18n/terms.properties
+++ b/web/src/main/resources/org/akaza/openclinica/i18n/terms.properties
@@ -184,7 +184,7 @@ genetic = genetic
 
 greater_than = greater than
 
-greater_than_or_equal_to = greater than 
+greater_than_or_equal_to = greater than or equal
 
 guest = guest
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/auditDatabase.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/auditDatabase.jsp
@@ -36,7 +36,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
         <b><fmt:message key="instructions" bundle="${resword}"/></b>
 
@@ -50,7 +50,7 @@
 <tr id="sidebar_Instructions_closed" style="display: all">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
         <b><fmt:message key="instructions" bundle="${resword}"/></b>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/auditUserActivity.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/auditUserActivity.jsp
@@ -36,7 +36,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -50,7 +50,7 @@
 <tr id="sidebar_Instructions_closed" style="display: all">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/batchCRFMigration.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/batchCRFMigration.jsp
@@ -22,7 +22,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 	<td class="sidebar_tab"><a
 		href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right"
-			hspace="10"></a> <b><fmt:message key="instructions"
+			hspace="10"></span></a> <b><fmt:message key="instructions"
 				bundle="${restext}" /></b>
 
 		<div class="sidebar_tab_content"></div></td>
@@ -30,7 +30,7 @@
 </tr>
 <tr id="sidebar_Instructions_closed" style="display: all">
 	<td class="sidebar_tab"><a
-		href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 		<b><fmt:message key="instructions" bundle="${resword}" /></b>
 		<div class="sidebar_tab_content">
 			<fmt:message key="choose_crf_migration_batch_instruction_key"

--- a/web/src/main/webapp/WEB-INF/jsp/admin/configuration.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/configuration.jsp
@@ -12,7 +12,7 @@
 <tr id="sidebar_Instructions_open" style="display: all">
         <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -26,7 +26,7 @@
     <tr id="sidebar_Instructions_closed" style="display: none">
         <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="images/icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="images/icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/configurationPasswordRequirements.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/configurationPasswordRequirements.jsp
@@ -14,7 +14,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
     <b><fmt:message key="instructions" bundle="${resword}"/></b>
 
@@ -28,7 +28,7 @@
   <tr id="sidebar_Instructions_closed" style="display: all">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
     <b><fmt:message key="instructions" bundle="${resword}"/></b>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/createCRFConfirm.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/createCRFConfirm.jsp
@@ -21,7 +21,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		s
 
@@ -35,7 +35,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		Instructions
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/createCRFVersion.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/createCRFVersion.jsp
@@ -27,7 +27,7 @@
 
     <a href="javascript:leftnavExpand('sidebar_Instructions_open');
     leftnavExpand('sidebar_Instructions_closed');">
-            <span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+            <span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -54,7 +54,7 @@
 
     <a href="javascript:leftnavExpand('sidebar_Instructions_open');
     leftnavExpand('sidebar_Instructions_closed');">
-            <span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+            <span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/createCRFVersionConfirmSQL.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/createCRFVersionConfirmSQL.jsp
@@ -21,7 +21,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -35,7 +35,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/createCRFVersionDone.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/createCRFVersionDone.jsp
@@ -21,7 +21,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="iicon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="iicon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -35,7 +35,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/createCRFVersionError.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/createCRFVersionError.jsp
@@ -22,7 +22,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -36,7 +36,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/createCRFVersionNoDelete.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/createCRFVersionNoDelete.jsp
@@ -19,7 +19,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -33,7 +33,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/createExportJob.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/createExportJob.jsp
@@ -17,7 +17,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -31,7 +31,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/createImportJob.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/createImportJob.jsp
@@ -16,7 +16,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -30,7 +30,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/createXformCRFVersion.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/createXformCRFVersion.jsp
@@ -27,7 +27,7 @@
 
         <a href="javascript:leftnavExpand('sidebar_Instructions_open');
         leftnavExpand('sidebar_Instructions_closed');">
-            <span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+            <span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -54,7 +54,7 @@
 
         <a href="javascript:leftnavExpand('sidebar_Instructions_open');
         leftnavExpand('sidebar_Instructions_closed');">
-            <span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+            <span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/createuseraccount.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/createuseraccount.jsp
@@ -12,7 +12,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -26,7 +26,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/deleteCRFVersion.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/deleteCRFVersion.jsp
@@ -14,7 +14,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10" alt="-" title=""></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10" alt="-" title=""></span></a>
 
 		Instructions
 
@@ -28,7 +28,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10" alt="v" title=""></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10" alt="v" title=""></span></a>
 
 		Instructions
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/editstudyuserrole.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/editstudyuserrole.jsp
@@ -12,7 +12,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -26,7 +26,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/edituseraccount.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/edituseraccount.jsp
@@ -12,7 +12,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
         <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -26,7 +26,7 @@
     <tr id="sidebar_Instructions_closed" style="display: all">
         <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/edituseraccountconfirm.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/edituseraccountconfirm.jsp
@@ -12,7 +12,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
         <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="iicon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -26,7 +26,7 @@
     <tr id="sidebar_Instructions_closed" style="display: all">
         <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/removeCRF.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/removeCRF.jsp
@@ -20,7 +20,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -34,7 +34,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/removeCRFVersion.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/removeCRFVersion.jsp
@@ -22,7 +22,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="iicon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="iicon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -36,7 +36,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/removeCRFVersionConfirm.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/removeCRFVersionConfirm.jsp
@@ -19,7 +19,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -33,7 +33,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/studyAuditLog.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/studyAuditLog.jsp
@@ -37,7 +37,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -51,7 +51,7 @@
 <tr id="sidebar_Instructions_closed" style="display: all">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/viewCRF.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/viewCRF.jsp
@@ -44,7 +44,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -58,7 +58,7 @@
 <tr id="sidebar_Instructions_closed" style="display: all">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/viewImportJobs.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/viewImportJobs.jsp
@@ -15,7 +15,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -29,7 +29,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/viewJobs.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/viewJobs.jsp
@@ -15,7 +15,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -29,7 +29,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/viewuseraccount.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/viewuseraccount.jsp
@@ -18,7 +18,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -32,7 +32,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/extract.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/extract.jsp
@@ -15,7 +15,7 @@
 <tr id="sidebar_Instructions_open">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${restext}"/>
 
@@ -31,7 +31,7 @@
 <tr id="sidebar_Instructions_closed" style="display: none">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${restext}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/extract/createDatasetBegin.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/extract/createDatasetBegin.jsp
@@ -17,7 +17,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -31,7 +31,7 @@
   <tr id="sidebar_Instructions_closed" style="display: all">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/extract/createDatasetConfirmMetadata.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/extract/createDatasetConfirmMetadata.jsp
@@ -14,7 +14,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -28,7 +28,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/extract/createDatasetStep2.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/extract/createDatasetStep2.jsp
@@ -41,7 +41,7 @@ function notSelectAll() {
 <tr id="sidebar_Instructions_open" style="display: none">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -55,7 +55,7 @@ function notSelectAll() {
   <tr id="sidebar_Instructions_closed" style="display: all">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/extract/createDatasetStep3.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/extract/createDatasetStep3.jsp
@@ -15,7 +15,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -29,7 +29,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 		<c:if test="${newDataset.id>0}">

--- a/web/src/main/webapp/WEB-INF/jsp/extract/createDatasetStep4.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/extract/createDatasetStep4.jsp
@@ -17,7 +17,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -31,7 +31,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 		<c:if test="${newDataset.id>0}">

--- a/web/src/main/webapp/WEB-INF/jsp/extract/editDataset.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/extract/editDataset.jsp
@@ -14,7 +14,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -28,7 +28,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/extract/exportDatasets.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/extract/exportDatasets.jsp
@@ -22,7 +22,7 @@
 <!-- then instructions-->
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 		<fmt:message key="instructions" bundle="${resword}"/>
 		<div class="sidebar_tab_content">
 		</div>
@@ -31,7 +31,7 @@
 	</tr>
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 		<fmt:message key="instructions" bundle="${resword}"/>
 		</td>
   </tr>

--- a/web/src/main/webapp/WEB-INF/jsp/extract/selectCRFAttributes.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/extract/selectCRFAttributes.jsp
@@ -13,7 +13,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -27,7 +27,7 @@
   <tr id="sidebar_Instructions_closed" style="display: all">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/extract/selectEventAttribute.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/extract/selectEventAttribute.jsp
@@ -16,7 +16,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -30,7 +30,7 @@
   <tr id="sidebar_Instructions_closed" style="display: all">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/extract/selectGroupAttribute.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/extract/selectGroupAttribute.jsp
@@ -40,7 +40,7 @@ function notSelectAll() {
 <tr id="sidebar_Instructions_open" style="display: none">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -54,7 +54,7 @@ function notSelectAll() {
   <tr id="sidebar_Instructions_closed" style="display: all">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/extract/selectSubAttribute.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/extract/selectSubAttribute.jsp
@@ -16,7 +16,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -30,7 +30,7 @@
   <tr id="sidebar_Instructions_closed" style="display: all">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/extract/viewSelected.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/extract/viewSelected.jsp
@@ -43,7 +43,7 @@ function notSelectAll() {
 <tr id="sidebar_Instructions_open" style="display: none">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -57,7 +57,7 @@ function notSelectAll() {
   <tr id="sidebar_Instructions_closed" style="display: all">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/include/sideAlert.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/sideAlert.jsp
@@ -23,7 +23,7 @@
 	<tr id="sidebar_Alerts_open" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Alerts_open'); leftnavExpand('sidebar_Alerts_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Alerts_open'); leftnavExpand('sidebar_Alerts_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="alerts_messages" bundle="${resword}"/>
 
@@ -52,7 +52,7 @@
 	<tr id="sidebar_Alerts_closed" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Alerts_open'); leftnavExpand('sidebar_Alerts_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Alerts_open'); leftnavExpand('sidebar_Alerts_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="alerts_messages" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/listCurrentScheduledJobs.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/listCurrentScheduledJobs.jsp
@@ -16,7 +16,7 @@
 <tr id="sidebar_Instructions_open">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${restext}"/>
 
@@ -32,7 +32,7 @@
 <tr id="sidebar_Instructions_closed" style="display: none">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${restext}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/chooseCRFVersion.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/chooseCRFVersion.jsp
@@ -23,7 +23,7 @@
 <tr id="sidebar_Instructions_open" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -37,7 +37,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/createStudy1.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/createStudy1.jsp
@@ -17,7 +17,7 @@
 <tr id="sidebar_Instructions_open" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -31,7 +31,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/createStudy2.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/createStudy2.jsp
@@ -17,7 +17,7 @@
 <tr id="sidebar_Instructions_open" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -31,7 +31,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/createStudy3.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/createStudy3.jsp
@@ -16,7 +16,7 @@
 <tr id="sidebar_Instructions_open" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -30,7 +30,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/createStudy4.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/createStudy4.jsp
@@ -14,7 +14,7 @@
 <tr id="sidebar_Instructions_open" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -28,7 +28,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/createStudy5.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/createStudy5.jsp
@@ -14,7 +14,7 @@
 <tr id="sidebar_Instructions_open" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -28,7 +28,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/createStudy6.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/createStudy6.jsp
@@ -15,7 +15,7 @@
 <tr id="sidebar_Instructions_open" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -29,7 +29,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/createStudy7.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/createStudy7.jsp
@@ -15,7 +15,7 @@
 <tr id="sidebar_Instructions_open" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -29,7 +29,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/createStudy8.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/createStudy8.jsp
@@ -14,7 +14,7 @@
 <tr id="sidebar_Instructions_open" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -28,7 +28,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/createSubStudy.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/createSubStudy.jsp
@@ -15,7 +15,7 @@
 <tr id="sidebar_Instructions_open" style="display: all">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -29,7 +29,7 @@
   <tr id="sidebar_Instructions_closed" style="display: none">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/defineStudyEvent1.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/defineStudyEvent1.jsp
@@ -16,7 +16,7 @@
 <tr id="sidebar_Instructions_open" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -31,7 +31,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/defineStudyEvent2.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/defineStudyEvent2.jsp
@@ -16,7 +16,7 @@
 <tr id="sidebar_Instructions_open" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -30,7 +30,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/defineStudyEvent3.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/defineStudyEvent3.jsp
@@ -16,7 +16,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -30,7 +30,7 @@
 <tr id="sidebar_Instructions_closed" style="display: all">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/defineStudyEvent4.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/defineStudyEvent4.jsp
@@ -16,7 +16,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -30,7 +30,7 @@
 <tr id="sidebar_Instructions_closed" style="display: all">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/listEventsForSubjects.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/listEventsForSubjects.jsp
@@ -49,7 +49,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -63,7 +63,7 @@
 <tr id="sidebar_Instructions_closed" style="display: all">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -72,7 +72,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="info" bundle="${resword}"/>
 
@@ -86,7 +86,7 @@
 <tr id="sidebar_Instructions_closed" style="display: all">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="info" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/removeStudySubject.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/removeStudySubject.jsp
@@ -24,7 +24,7 @@
 <tr id="sidebar_Instructions_open" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -38,7 +38,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/setUserRoleInStudy.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/setUserRoleInStudy.jsp
@@ -15,7 +15,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -29,7 +29,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudyEvent.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudyEvent.jsp
@@ -36,7 +36,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -49,7 +49,7 @@
   <tr id="sidebar_Instructions_closed" style="display: all">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudyEventSigned.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudyEventSigned.jsp
@@ -35,7 +35,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
         <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -48,7 +48,7 @@
     <tr id="sidebar_Instructions_closed" style="display: all">
         <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudyNew.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudyNew.jsp
@@ -53,7 +53,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -66,7 +66,7 @@
   <tr id="sidebar_Instructions_closed" style="display: all">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudySubject.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudySubject.jsp
@@ -28,7 +28,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
         <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -41,7 +41,7 @@
     <tr id="sidebar_Instructions_closed" style="display: all">
         <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/viewCRFVersion.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/viewCRFVersion.jsp
@@ -20,7 +20,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -34,7 +34,7 @@
   <tr id="sidebar_Instructions_closed">
     <td class="sidebar_tab">
 
-    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
     <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/viewNotes.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/viewNotes.jsp
@@ -44,7 +44,7 @@
 <tr id="sidebar_Instructions_open">
         <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -58,7 +58,7 @@
     <tr id="sidebar_Instructions_closed" style="display: none">
         <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/menu.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/menu.jsp
@@ -68,7 +68,7 @@
 <tr id="sidebar_Instructions_open" style="display: all">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -82,7 +82,7 @@
 <tr id="sidebar_Instructions_closed" style="display: none">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/submit/addNewSubjectExpressNew.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/addNewSubjectExpressNew.jsp
@@ -331,7 +331,7 @@
             </c:if>
 
                 <tr valign="top">
-                    <td class="formlabel" align="left"><span class="addNewStudyLayout"><fmt:message key="SED_2" bundle="${resword}"/></span>&nbsp;<small class="required">*</small></td>
+                    <td class="formlabel" align="left"><span class="addNewStudyLayout"><fmt:message key="SED_2" bundle="${resword}"/></span></td>
                     <td valign="top">
                         <table border="0" cellpadding="0" cellspacing="0">
                             <tr><td>

--- a/web/src/main/webapp/WEB-INF/jsp/submit/createNewStudyEvent.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/createNewStudyEvent.jsp
@@ -15,7 +15,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="down" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="down" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 
@@ -29,7 +29,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: all">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/submit/viewRules.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/viewRules.jsp
@@ -23,7 +23,7 @@
 <tr id="sidebar_Instructions_open" style="display: none">
         <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 
@@ -37,7 +37,7 @@
     <tr id="sidebar_Instructions_closed" style="display: all">
         <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/viewAllSubjectSDV.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/viewAllSubjectSDV.jsp
@@ -16,7 +16,7 @@
 <tr id="sidebar_Instructions_open">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${restext}"/>
 
@@ -32,7 +32,7 @@
 <tr id="sidebar_Instructions_closed" style="display: none">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${restext}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/viewAllSubjectSDVform.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/viewAllSubjectSDVform.jsp
@@ -17,7 +17,7 @@
 <tr id="sidebar_Instructions_open">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${restext}"/>
 
@@ -33,7 +33,7 @@
 <tr id="sidebar_Instructions_closed" style="display: none">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${restext}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/viewSubjectAggregate.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/viewSubjectAggregate.jsp
@@ -16,7 +16,7 @@
 <tr id="sidebar_Instructions_open">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${restext}"/>
 
@@ -32,7 +32,7 @@
 <tr id="sidebar_Instructions_closed" style="display: none">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${restext}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/viewSubjectAggregateSDV.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/viewSubjectAggregateSDV.jsp
@@ -16,7 +16,7 @@
 <tr id="sidebar_Instructions_open">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-down gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${restext}"/>
 
@@ -32,7 +32,7 @@
 <tr id="sidebar_Instructions_closed" style="display: none">
     <td class="sidebar_tab">
 
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="iicon icon-caret-right gray" border="0" align="right" hspace="10"></a>
+        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="iicon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
         <fmt:message key="instructions" bundle="${restext}"/>
 

--- a/web/src/main/webapp/includes/global_functions_javascript.js
+++ b/web/src/main/webapp/includes/global_functions_javascript.js
@@ -96,6 +96,15 @@ function hideCols(tableId,columnNumArray,showTable){
         }
     }
 
+    //spesial case for queries/listNotes
+    if (tableId === "listNotes") {
+        if (showTable) {
+            jQuery('body').addClass(BrowserDetect.browser==='Explorer' ? 'extra-width-ie' : 'extra-width');
+        } else {
+            jQuery('body').removeClass(BrowserDetect.browser==='Explorer' ? 'extra-width-ie' : 'extra-width');
+        }
+    }
+
 }
 
 function toggleName(str){

--- a/web/src/main/webapp/includes/styles.css
+++ b/web/src/main/webapp/includes/styles.css
@@ -615,6 +615,9 @@ form[action="UpdateSubStudy"] .textbox_center td.table_cell, form[action="Update
 .jmesa table:not(#studyAuditLogs) .odd > td, .jmesa table:not(#studyAuditLogs) .even > td, .jmesa table:not(#studyAuditLogs) .highlight > td {
   vertical-align: top; }
 
+.jmesa table#findSubjects .odd > td, .jmesa table#findSubjects .even > td, .jmesa table#findSubjects .highlight > td, .jmesa table#findSubjects td table td {
+  vertical-align: middle; }
+
 .jmesa table:not(#studyAuditLogs) .odd td, .jmesa table:not(#studyAuditLogs) .even td, .jmesa table:not(#studyAuditLogs) .highlight td {
   border: none;
   font-family: 'Open Sans', arial, helvetica, sans-serif;

--- a/web/src/main/webapp/includes/styles.css
+++ b/web/src/main/webapp/includes/styles.css
@@ -864,3 +864,20 @@ div#subjectSDV table#sdv {
   border-bottom-left-radius: 0;
   margin-left: -2px;
 }
+
+body.extra-width {
+  overflow-x: auto;
+  width: 120% !important; 
+}
+
+.extra-width #subnav_Tasks {
+  right: -20% !important;  
+}
+
+body.extra-width-ie {
+  overflow-x: auto;
+}
+
+.extra-width-ie #subnav_Tasks {
+  right: -37% !important;  
+}


### PR DESCRIPTION
- Subject Matrix - Event icons are misaligned with the action icons. The action icons need to be centered vertically to match the Event icons.
![screenshot from 2017-10-14 14-32-35](https://user-images.githubusercontent.com/13865076/31575300-fb68dc46-b115-11e7-82a3-162a250b6919.png)

- Subject Matrix - Click an event icon for an event. In the modal popup, remove “Status: “. Just display the event status without the label. Make sure this works for an event with 1 occurrence and an event with more than 1 occurrence.
![screenshot from 2017-10-14 19-31-03](https://user-images.githubusercontent.com/13865076/31575306-3cd7c408-b116-11e7-8628-b97ed200c9bc.png)

- Make the Study Event selection not required. It is already letting me save it without selecting a value, but it is still showing it with a red asterisk. 
![screenshot from 2017-10-14 19-32-10](https://user-images.githubusercontent.com/13865076/31575318-67296360-b116-11e7-84b6-01616a5032a1.png)

- IE11 unable to guess strings with no markup
![screenshot from 2017-10-14 19-24-45](https://user-images.githubusercontent.com/13865076/31575321-79dd4b8e-b116-11e7-9865-3fc611e9da9c.png)
