### PR TITLE
Manual Testing/Bug Fixing - Misc Cosmetic Issues (Oct 16 progress)

### DIFF
--- a/web/src/main/resources/org/akaza/openclinica/i18n/notes.properties
+++ b/web/src/main/resources/org/akaza/openclinica/i18n/notes.properties
@@ -271,6 +271,8 @@ generate_dataset_HTML_instructions2 = You may click on each column name link to 
 
 get_subject_oid_from_matrix_show_more = For Study Subject OIDs select show more in the
 
+subject_matrix = Subject Matrix
+
 go_back = Go Back
 
 go_back_to_the_CRF_list = Go back to the CRF List

--- a/web/src/main/webapp/WEB-INF/jsp/admin/viewFullStudy.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/viewFullStudy.jsp
@@ -75,7 +75,7 @@
 
 <a style="text-decoration:none" href="javascript:openDocWindow('DownloadStudyMetadata?studyId=<c:out value="${studyToView.id}"/>');"><fmt:message key="download_study_meta" bundle="${restext}"/></a>.
 <fmt:message key="get_subject_oid_from_matrix_show_more" bundle="${restext}"/>
-<a style="text-decoration:none" href="ListStudySubjects">Subject Matrix</a>.
+<a style="text-decoration:none" href="ListStudySubjects"><fmt:message key="subject_matrix" bundle="${restext}"/></a>.
 
 <br><br>
 <a href="javascript:leftnavExpand('overview');" style="text-decoration:none;">
@@ -101,7 +101,7 @@
   <c:out value="${studyToView.principalInvestigator}"/>
   </td></tr>
   <tr valign="top"><td class="table_header_column"><fmt:message key="brief_summary" bundle="${resword}"/>:</td><td class="table_cell">
-  <c:out value="${studyToView.description}"/>&nbsp;
+  <c:out value="${studyToView.name}"/>&nbsp;
   </td></tr>
 
   <tr valign="top"><td class="table_header_column"><fmt:message key="owner" bundle="${resword}"/>:</td><td class="table_cell">

--- a/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
@@ -252,7 +252,7 @@
         <div class="taskLeftColumn">
             <div class="taskLink"><a href="${urlPrefix}ListStudySubjects"><fmt:message key="nav_subject_matrix" bundle="${resword}"/></a></div>
             <c:if test="${study.status.available}">
-                <div class="taskLink"><a href="javascript:;" id="navAddSubject"><fmt:message key="nav_add_subject" bundle="${resword}"/></a></div>
+                <div class="taskLink"><a href="javascript:;" id="navAddSubjectSD"><fmt:message key="nav_add_subject" bundle="${resword}"/></a></div>
             </c:if>
             <div class="taskLink"><a href="${urlPrefix}ViewNotes?module=submit"><fmt:message key="queries" bundle="${resword}"/></a></div>
         </div>
@@ -270,7 +270,7 @@
         <div class="taskLeftColumn">
             <div class="taskLink"><a href="${urlPrefix}ListStudySubjects"><fmt:message key="nav_subject_matrix" bundle="${resword}"/></a></div>
             <c:if test="${study.status.available}">
-                <div class="taskLink"><a href="javascript:;" id="navAddSubject"><fmt:message key="nav_add_subject" bundle="${resword}"/></a></div>
+                <div class="taskLink"><a href="javascript:;" id="navAddSubjectSD"><fmt:message key="nav_add_subject" bundle="${resword}"/></a></div>
             </c:if>
             <div class="taskLink"><a href="${urlPrefix}ViewNotes?module=submit"><fmt:message key="queries" bundle="${resword}"/></a></div>
         </div>
@@ -296,7 +296,7 @@
         <div class="taskLeftColumn">
             <div class="taskLink"><a href="${urlPrefix}ListStudySubjects"><fmt:message key="nav_subject_matrix" bundle="${resword}"/></a></div>
             <c:if test="${study.status.available}">
-                <div class="taskLink"><a href="javascript:;" id="navAddSubject"><fmt:message key="nav_add_subject" bundle="${resword}"/></a></div>
+                <div class="taskLink"><a href="javascript:;" id="navAddSubjectSD"><fmt:message key="nav_add_subject" bundle="${resword}"/></a></div>
             </c:if>
             <div class="taskLink"><a href="${urlPrefix}ViewNotes?module=submit"><fmt:message key="queries" bundle="${resword}"/></a></div>
         </div>
@@ -347,6 +347,16 @@
 <script type="text/javascript">
     jQuery(document).ready(function () {
         jQuery('#navAddSubject').click(function () {
+            jQuery.blockUI({message: jQuery('#navAddSubjectForm'), css: {left: "300px", top: "10px"}});
+        });
+
+        jQuery('#cancel').click(function () {
+            jQuery.unblockUI();
+            return false;
+        });
+    });
+    jQuery(document).ready(function () {
+        jQuery('#navAddSubjectSD').click(function () {
             jQuery.blockUI({message: jQuery('#navAddSubjectForm'), css: {left: "300px", top: "10px"}});
         });
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/findSubjects.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/findSubjects.jsp
@@ -88,7 +88,7 @@
     </form>
 </div>
 
-<c:if test="${userRole.coordinator}">
+<c:if test="${userRole.monitor || userRole.coordinator || userRole.director || userRole.investigator || userRole.researchAssistant || userRole.researchAssistant2}">
     <div id="addSubjectForm" style="display:none;">
           <c:import url="../submit/addNewSubjectExpressNew.jsp">
           </c:import>

--- a/web/src/main/webapp/WEB-INF/jsp/submit/enterDataForStudyEvent.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/enterDataForStudyEvent.jsp
@@ -339,7 +339,7 @@
     <c:when test="${studyEvent.subjectEventStatus.name=='locked'}">
         <%--<c:when test="${dedc.status.name=='locked'}">--%>
         <td class="table_cell" bgcolor="#F5F5F5" align="center">
-            <span class="icon icon-icon-locked" alt="<fmt:message key="locked" bundle="${resword}"/>" title="<fmt:message key="locked" bundle="${resword}"/>"></span>
+            <span class="icon icon-lock" alt="<fmt:message key="locked" bundle="${resword}"/>" title="<fmt:message key="locked" bundle="${resword}"/>"></span>
         </td>
     </c:when>
 


### PR DESCRIPTION
On View Event screen forms that are not yet started are not displaying the correct icon (see top icon for Form 9 in this screenshot). On View Subject screen, all forms (started or not started) are displaying the wrong icon. On Subject Matrix, locked event is displaying the wrong icon. The icon for Locked Forms should be the “lock” icon for all started or not started forms on View Event and View Subject. The icon for Locked Events should also be the “lock” icon on the Subject Matrix.
before:
![before](https://user-images.githubusercontent.com/16472454/31603716-32167430-b28b-11e7-82cb-400bb62da92e.png)
after:
![after](https://user-images.githubusercontent.com/16472454/31603722-3810ed52-b28b-11e7-9c3c-260618f1c249.png)

