### PR TITLE
Manual Testing/Bug Fixing - Misc Cosmetic Issues (Oct 19 progress)

### DIFF
--- a/web/src/main/webapp/WEB-INF/jsp/admin/viewCRF.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/viewCRF.jsp
@@ -183,10 +183,6 @@
                 </table>
                 </div></div></div></div></div></div></div></div></div></div>
 
-
-<br/>
-<span class="title_Manage" style="font-weight: bold;"><fmt:message key="studies_using_crf" bundle="${resword}"/></span>
-
 <div id="studiesDiv">
     <form  action="${pageContext.request.contextPath}/ViewCRF">
         <input type="hidden" name="module" value="admin">

--- a/web/src/main/webapp/WEB-INF/jsp/admin/viewFullStudy.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/viewFullStudy.jsp
@@ -129,7 +129,7 @@
 <div class="tablebox_center">
 <table border="0" cellpadding="0" cellspacing="0" width="100%">
   <tr valign="top"><td class="table_header_column"><a href="http://prsinfo.clinicaltrials.gov/definitions.html#BriefTitle" target="def_win" onClick="openDefWindow('http://prsinfo.clinicaltrials.gov/definitions.html#BriefTitle'); return false;"><fmt:message key="brief_title" bundle="${resword}"/></a>:</td><td class="table_cell">
-  <c:out value="${studyToView.name}"/>
+  <c:out value="${studyToView.summary}"/>
   </td></tr>
 
   <tr valign="top"><td class="table_header_column"><a href="http://prsinfo.clinicaltrials.gov/definitions.html#PrimaryId" target="def_win" onClick="openDefWindow('http://prsinfo.clinicaltrials.gov/definitions.html#PrimaryId'); return false;"><fmt:message key="unique_protocol_ID" bundle="${resword}"/></a>:</td><td class="table_cell">


### PR DESCRIPTION
Tasks > Monitor and Manage Data > CRFs > Click the view icon for a CRF to open the View CRF Details page: Remove the text at the bottom - “Studies Using This CRF For Data Entry”
before:
![studies using crf_before](https://user-images.githubusercontent.com/16472454/31769646-a803f5c6-b4fe-11e7-932d-de0817441c7a.png)
after:
![after](https://user-images.githubusercontent.com/16472454/31769651-aca561fa-b4fe-11e7-800c-82faaaf22979.png)
