### PR TITLE
Manual Testing/Bug Fixing - Misc Cosmetic Issues

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/ViewStudySubjectServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/ViewStudySubjectServlet.java
@@ -76,7 +76,7 @@ import org.springframework.web.context.support.WebApplicationContextUtils;
  */
 public class ViewStudySubjectServlet extends SecureController {
     // The study subject has an existing discrepancy note related to their
-    // unique identifier; this
+    // person id; this
     // value will be saved as a request attribute
     public final static String HAS_UNIQUE_ID_NOTE = "hasUniqueIDNote";
     // The study subject has an existing discrepancy note related to their date

--- a/web/src/main/java/org/akaza/openclinica/control/submit/ListStudySubjectTableFactory.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ListStudySubjectTableFactory.java
@@ -733,7 +733,7 @@ public class ListStudySubjectTableFactory extends AbstractTableFactory {
             StringBuilder url = new StringBuilder();
             url.append(eventDivBuilder(subject, rowcount, studyEvents, studyEventDefinition, studySubjectBean));
             url.append("<span class='" + imageIconPaths.get(subjectEventStatus.getId()) + "' style='padding-top: 2px; padding-bottom: 3px;'>");
-            url.append("</a></td><td align='left' width='10px'><span style='color: #668cff; padding-bottom: 145px; font-size: 13px;'>"+getCount()+" </span></td></tr></table>");
+            url.append("<span style='color: #668cff; padding-bottom: 145px; font-size: 13px;'>"+getCount()+"</span></a></td></tr></table>");
 
             return url.toString();
         }

--- a/web/src/main/resources/org/akaza/openclinica/i18n/page_messages.properties
+++ b/web/src/main/resources/org/akaza/openclinica/i18n/page_messages.properties
@@ -720,7 +720,7 @@ subject_reassigned = The Subject {0} has been reassigned to Study/Site {1}.
 
 subject_updated_succcesfully = The Subject has been updated successfully.
 
-subject_with_unique_identifier = The Subject with unique identifier '
+subject_with_unique_identifier = The Subject with person id '
 
 the = The
 

--- a/web/src/main/resources/org/akaza/openclinica/i18n/words.properties
+++ b/web/src/main/resources/org/akaza/openclinica/i18n/words.properties
@@ -2171,7 +2171,7 @@ type = Type
 
 uncompleted_items = Uncompleted Items
 
-unique_identifier = Unique Identifier
+unique_identifier = Person ID
 
 unique_protocol_ID = Unique Protocol ID
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/viewCRF.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/viewCRF.jsp
@@ -112,9 +112,7 @@
                             <tr>
                                 <td>
                                    
-                                    <a href="EnketoFormServlet?formLayoutId=<c:out value="${version.id}"/>&studyEventId=<c:out value="0"/>&eventCrfId=<c:out value="0"/>&originatingPage=<c:out value="${originatingPage}"/>&mode=<c:out value="view"/>"       
-                                       onMouseDown="javascript:setImage('bt_View1','images/bt_View_d.gif');"
-                                       onMouseUp="javascript:setImage('bt_View1','images/bt_View.gif');"><span
+                                    <a href="${urlPrefix}ListCRF?module=manage"/><span
                                             name="bt_View1" class="icon icon-search" border="0" alt="<fmt:message key="view" bundle="${resword}"/>" title="<fmt:message key="view" bundle="${resword}"/>" align="left" hspace="6"></a>
                                 </td>
                                 <td>

--- a/web/src/main/webapp/WEB-INF/jsp/admin/viewCRF.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/viewCRF.jsp
@@ -98,7 +98,6 @@
                     <td class="table_header_row_left"><fmt:message key="version_name" bundle="${resword}"/></td>
                     <td class="table_header_row"><fmt:message key="oid" bundle="${resword}"/></td>
                     <td class="table_header_row"><fmt:message key="status" bundle="${resword}"/></td>
-                    <td class="table_header_row"><fmt:message key="revision_notes" bundle="${resword}"/></td>
                     <td class="table_header_row"><fmt:message key="action" bundle="${resword}"/></td>
                 </tr>
                 <c:forEach var ="version" items="${crf.versions}">
@@ -106,7 +105,6 @@
                     <td class="table_cell_left"><c:out value="${version.name}"/></td>
                     <td class="table_cell"><c:out value="${version.oid}"/></td>
                     <td class="table_cell"><c:out value="${version.status.name}"/></td>
-                    <td class="table_cell"><c:out value="${version.revisionNotes}"/></td>
                     <td class="table_cell">
                         <table border="0" cellpadding="0" cellspacing="0">
                             <tr>

--- a/web/src/main/webapp/WEB-INF/jsp/admin/viewCRF.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/viewCRF.jsp
@@ -141,7 +141,6 @@
                 <tr valign="top">
                     <td class="table_header_row_left"><fmt:message key="name" bundle="${resword}"/></td>
                     <td class="table_header_row"><fmt:message key="item_oid" bundle="${resword}"/></td>
-                    <td class="table_header_row"><fmt:message key="description" bundle="${resword}"/></td>
                     <td class="table_header_row"><fmt:message key="data_type" bundle="${resword}"/></td>
                     <%--<td class="table_header_row"><fmt:message key="versions" bundle="${resword}"/></td>--%>
                     <td class="table_header_row"><fmt:message key="integrity_check" bundle="${resword}"/></td>
@@ -151,7 +150,6 @@
                     <td class="table_cell_left">
                      <c:if test="${item.id > 0}"><a href="javascript: openDocWindow('ViewItemDetail?itemId=<c:out value="${item.id}"/>')"></c:if><c:out value="${item.itemName}"/> <c:if test="${item.id > 0}"></a></c:if></td>
                     <td class="table_cell"><c:out value="${item.itemOID}"/></td>
-                    <td class="table_cell"><c:out value="${item.itemDescription}"/></td>
                     <td class="table_cell"><c:out value="${item.itemDataType}"/></td>
                     <%--<td class="table_cell"><c:out value="${item.versions}"/></td>--%>
                     <td class="table_cell">

--- a/web/src/main/webapp/WEB-INF/jsp/admin/viewCRF.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/viewCRF.jsp
@@ -79,9 +79,6 @@
                 <tr valign="top"><td class="table_header_column_top"><fmt:message key="name" bundle="${resword}"/>:</td><td class="table_cell">
                     <c:out value="${crf.name}"/>
                 </td></tr>
-                <tr valign="top"><td class="table_header_column"><fmt:message key="description" bundle="${resword}"/>:</td><td class="table_cell">
-                    <c:out value="${crf.description}"/>
-                </td></tr>
                 <tr valign="top"><td class="table_header_column"><fmt:message key="OID" bundle="${resword}"/>:</td><td class="table_cell">
                     <c:out value="${crf.oid}"/>
                 </td></tr>

--- a/web/src/main/webapp/WEB-INF/jsp/admin/viewCRF.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/viewCRF.jsp
@@ -97,7 +97,6 @@
                 <tr valign="top">
                     <td class="table_header_row_left"><fmt:message key="version_name" bundle="${resword}"/></td>
                     <td class="table_header_row"><fmt:message key="oid" bundle="${resword}"/></td>
-                    <td class="table_header_row"><fmt:message key="description" bundle="${resword}"/></td>
                     <td class="table_header_row"><fmt:message key="status" bundle="${resword}"/></td>
                     <td class="table_header_row"><fmt:message key="revision_notes" bundle="${resword}"/></td>
                     <td class="table_header_row"><fmt:message key="action" bundle="${resword}"/></td>
@@ -106,7 +105,6 @@
                 <tr valign="top">
                     <td class="table_cell_left"><c:out value="${version.name}"/></td>
                     <td class="table_cell"><c:out value="${version.oid}"/></td>
-                    <td class="table_cell"><c:out value="${version.description}"/></td>
                     <td class="table_cell"><c:out value="${version.status.name}"/></td>
                     <td class="table_cell"><c:out value="${version.revisionNotes}"/></td>
                     <td class="table_cell">

--- a/web/src/main/webapp/WEB-INF/jsp/include/sideInfo.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/sideInfo.jsp
@@ -15,13 +15,12 @@
 <c:choose>
  <c:when test="${userBean != null && userBean.id>0}">
  <%-- BWP 3098 >> switch displays for Info box--%>
-    <tr id="sidebar_Info_open"<c:if test="${closeInfoShowIcons}">style="display: none"</c:if>>
+    <tr id="sidebar_Info_open"<c:if test="${!closeInfoShowIcons}">style="display: none"</c:if>>
 		<td class="sidebar_tab">
 
 		<a href="javascript:leftnavExpand('sidebar_Info_open'); leftnavExpand('sidebar_Info_closed');">
-
                <span class="icon icon-caret-down gray"></span>
-</a>
+		</a>
 
 		<fmt:message key="info" bundle="${restext}"/>
 
@@ -76,7 +75,7 @@
 		</td>
 	</tr>
     <%-- BWP 3098 >> switch displays for Info box--%>
-    <tr id="sidebar_Info_closed"<c:if test="${! closeInfoShowIcons}">style="display: none"</c:if>>
+    <tr id="sidebar_Info_closed"<c:if test="${closeInfoShowIcons}">style="display: none"</c:if>>
 		<td class="sidebar_tab">
 
 		<a href="javascript:leftnavExpand('sidebar_Info_open'); leftnavExpand('sidebar_Info_closed');"><span class="icon icon-caret-right gray"></span></a>

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/viewEventDefinitionReadOnly.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/viewEventDefinitionReadOnly.jsp
@@ -54,9 +54,6 @@
     <tr valign="top"><td class="table_header_column"><fmt:message key="oid" bundle="${resword}"/>:</td><td class="table_cell">  
   <c:out value="${definition.oid}"/>
    </td></tr>
-  <tr valign="top"><td class="table_header_column"><fmt:message key="description" bundle="${resword}"/>:</td><td class="table_cell">  
-  <c:out value="${definition.description}"/>&nbsp;
-  </td></tr>
  
  <tr valign="top"><td class="table_header_column"><fmt:message key="repeating" bundle="${resword}"/>:</td><td class="table_cell">
   <c:choose>
@@ -69,9 +66,6 @@
     <c:out value="${definition.type}"/>
    </td></tr>
   
-  <tr valign="top"><td class="table_header_column"><fmt:message key="category" bundle="${resword}"/>:</td><td class="table_cell">  
-  <c:out value="${definition.category}"/>&nbsp;
-  </td></tr>
   </table>
   </div>
 </div></div></div></div></div></div></div></div>

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/viewEventDefinitionReadOnly.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/viewEventDefinitionReadOnly.jsp
@@ -85,9 +85,7 @@
 <table border="0" cellpadding="0" cellspacing="0" width="100%"> 
  <tr valign="top"> 
     <td class="table_header_row"><fmt:message key="name" bundle="${resword}"/></td>   
-    <td valign="top" class="table_header_row"><fmt:message key="required" bundle="${resword}"/></td>     
-    <td valign="top" class="table_header_row"><fmt:message key="double_data_entry" bundle="${resword}"/></td>         
-    <td valign="top" class="table_header_row"><fmt:message key="password_required" bundle="${resword}"/></td>
+    <td valign="top" class="table_header_row"><fmt:message key="required" bundle="${resword}"/></td>             
     <!-- <td valign="top" class="table_header_row"><fmt:message key="enforce_decision_conditions" bundle="${restext}"/></td>-->
     <td valign="top" class="table_header_row"><fmt:message key="default_version" bundle="${resword}"/></td>
      <td valign="top" class="table_header_row"><fmt:message key="hidden_crf" bundle="${resword}"/></td>     
@@ -100,8 +98,7 @@
      <td valign="top" class="table_header_row"><fmt:message key="offline" bundle="${resword}"/></td>  
     </c:when>  
    </c:choose>
-
-     <td valign="top" class="table_header_row"><fmt:message key="null_values" bundle="${resword}"/></td>    
+   
      <td valign="top" class="table_header_row"><fmt:message key="sdv_option" bundle="${resword}"/></td>
     <td valign="top" class="table_header_row"><fmt:message key="status" bundle="${resword}"/></td>
     <td valign="top" class="table_header_row"><fmt:message key="actions" bundle="${resword}"/></td>
@@ -127,20 +124,6 @@
      <c:otherwise> <fmt:message key="no" bundle="${resword}"/> </c:otherwise>
     </c:choose>
    </td>
-     
-    <td class="table_cell">
-     <c:choose>
-      <c:when test="${crf.doubleEntry == true}"> <fmt:message key="yes" bundle="${resword}"/> </c:when>
-      <c:otherwise> <fmt:message key="no" bundle="${resword}"/> </c:otherwise>
-     </c:choose>
-    </td>         
-
-    <td class="table_cell">
-     <c:choose>
-      <c:when test="${crf.electronicSignature == true}"> <fmt:message key="yes" bundle="${resword}"/> </c:when>
-      <c:otherwise> <fmt:message key="no" bundle="${resword}"/> </c:otherwise>
-     </c:choose>
-    </td>
 
     <%--<td class="table_cell">
      <c:choose>
@@ -202,10 +185,7 @@
       </td>          
         </c:when>
       </c:choose>
-
-   <td class="table_cell"> 
-    <c:out value="${crf.nullValues}"/> &nbsp;    
-  </td>          
+       
   <td class="table_cell"><fmt:message key="${crf.sourceDataVerification.description}" bundle="${resterm}"/></td> 
    <td class="table_cell"><c:out value="${crf.status.name}"/></td> 
    <td class="table_cell">

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/viewSite.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/viewSite.jsp
@@ -346,8 +346,6 @@
  <tr valign="top">
     <td width="90px" class="table_header_row"><fmt:message key="name" bundle="${resword}"/></td>
     <td valign="top" class="table_header_row"><fmt:message key="required" bundle="${resword}"/></td>
-    <td valign="top" class="table_header_row"><fmt:message key="double_data_entry" bundle="${resword}"/></td>
-    <td valign="top" class="table_header_row"><fmt:message key="password_required" bundle="${resword}"/></td>
     <!-- <td valign="top" class="table_header_row"><fmt:message key="enforce_decision_conditions" bundle="${restext}"/></td>-->
     <td valign="top" class="table_header_row"><fmt:message key="default_version" bundle="${resword}"/></td>
      <td valign="top" class="table_header_row"><fmt:message key="hidden_crf" bundle="${resword}"/></td>
@@ -359,8 +357,6 @@
      <td valign="top" class="table_header_row"><fmt:message key="offline" bundle="${resword}"/></td>
     </c:when>
     </c:choose>
-     
-     <td valign="top" class="table_header_row"><fmt:message key="null_values" bundle="${resword}"/></td>
      <td valign="top" class="table_header_row"><fmt:message key="selected_verions" bundle="${resword}"/></td>
      <td valign="top" class="table_header_row"><fmt:message key="sdv_option" bundle="${resword}"/></td>
     <td valign="top" class="table_header_row"><fmt:message key="status" bundle="${resword}"/></td>
@@ -403,22 +399,6 @@
      <c:otherwise> <fmt:message key="no" bundle="${resword}"/> </c:otherwise>
     </c:choose>
    </td>
-
-    <td class="table_cell">
-     <c:choose>
-      <c:when test="${crf.doubleEntry == true}"> <fmt:message key="yes" bundle="${resword}"/> </c:when>
-      <c:otherwise> <fmt:message key="no" bundle="${resword}"/> </c:otherwise>
-     </c:choose>
-    </td>
-
-    <td class="table_cell">
-     <c:choose>
-      <c:when test="${crf.electronicSignature == true}"> <fmt:message key="yes" bundle="${resword}"/> </c:when>
-      <c:otherwise> <fmt:message key="no" bundle="${resword}"/> </c:otherwise>
-     </c:choose>
-    </td>
-
-  
 
    <td class="table_cell">
     <c:out value="${crf.defaultVersionName}"/>
@@ -465,10 +445,7 @@
     
    </c:when>  
  </c:choose>
-   
-   <td class="table_cell">
-    <c:out value="${crf.nullValues}"/> &nbsp;
-  </td>
+
   <td class="table_cell"><c:out value="${selectedVersionNames}"/></td>
   <td class="table_cell"><fmt:message key="${crf.sourceDataVerification.description}" bundle="${resterm}"/></td>
    <td class="table_cell"><c:out value="${crf.status.name}"/></td>

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/viewSite.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/viewSite.jsp
@@ -43,27 +43,27 @@
 
 <!-- then instructions-->
 <tr id="sidebar_Instructions_open" style="display: none">
-		<td class="sidebar_tab">
+    <td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><img src="images/sidebar_collapse.gif" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><img src="images/sidebar_collapse.gif" border="0" align="right" hspace="10"></a>
 
-		<b><fmt:message key="instructions" bundle="${resword}"/></b>
+    <b><fmt:message key="instructions" bundle="${resword}"/></b>
 
-		<div class="sidebar_tab_content">
+    <div class="sidebar_tab_content">
 
-		</div>
+    </div>
 
-		</td>
+    </td>
 
-	</tr>
-	<tr id="sidebar_Instructions_closed" style="display: all">
-		<td class="sidebar_tab">
+  </tr>
+  <tr id="sidebar_Instructions_closed" style="display: all">
+    <td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><img src="images/sidebar_expand.gif" border="0" align="right" hspace="10"></a>
+    <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><img src="images/sidebar_expand.gif" border="0" align="right" hspace="10"></a>
 
-		<b><fmt:message key="instructions" bundle="${resword}"/></b>
+    <b><fmt:message key="instructions" bundle="${resword}"/></b>
 
-		</td>
+    </td>
   </tr>
 <jsp:include page="../include/sideInfo.jsp"/>
 
@@ -110,10 +110,10 @@
     <img id="excl_siteProperties" src="images/bt_Collapse.gif" border="0"> <fmt:message key="view_site_properties" bundle="${resword}"/> </a></div>
 <c:choose>
 <c:when test="${idToSort>0}">
-	<div id="siteProperties" style="display: none">
+  <div id="siteProperties" style="display: none">
 </c:when>
 <c:otherwise>
-	<div id="siteProperties" style="display: all">
+  <div id="siteProperties" style="display: all">
 </c:otherwise>
 </c:choose>
 
@@ -134,20 +134,12 @@
   <c:out value="${siteToView.identifier}"/>
   </td></tr>
 
-  <tr valign="top"><td class="table_header_column"><fmt:message key="secondary_IDs" bundle="${resword}"/>:</td><td class="table_cell">
-   <c:out value="${siteToView.secondaryIdentifier}"/>
-   </td></tr>
-
-    <tr valign="top"><td class="table_header_column"><fmt:message key="OID" bundle="${resword}"/>:</td><td class="table_cell">
+  <tr valign="top"><td class="table_header_column"><fmt:message key="OID" bundle="${resword}"/>:</td><td class="table_cell">
    <c:out value="${siteToView.oid}"/>
    </td></tr>
 
   <tr valign="top"><td class="table_header_column"><fmt:message key="principal_investigator" bundle="${resword}"/>:</td><td class="table_cell">
   <c:out value="${siteToView.principalInvestigator}"/>
-  </td></tr>
-
-  <tr valign="top"><td class="table_header_column"><fmt:message key="brief_summary" bundle="${resword}"/>:</td><td class="table_cell">
-  <c:out value="${siteToView.summary}"/>
   </td></tr>
 
   <tr valign="top"><td class="table_header_column"><fmt:message key="protocol_verification" bundle="${resword}"/>:</td><td class="table_cell">
@@ -158,15 +150,8 @@
   <fmt:formatDate value="${siteToView.datePlannedStart}" pattern="${dteFormat}"/>&nbsp;
   </td></tr>
 
-  <tr valign="top"><td class="table_header_column"><fmt:message key="estimated_completion_date" bundle="${resword}"/>:</td><td class="table_cell">
-  <fmt:formatDate value="${siteToView.datePlannedEnd}" pattern="${dteFormat}"/>&nbsp;
-  </td></tr>
-
   <tr valign="top"><td class="table_header_column"><fmt:message key="expected_total_enrollment" bundle="${resword}"/>:</td><td class="table_cell">
   <c:out value="${siteToView.expectedTotalEnrollment}"/>&nbsp;
-  </td></tr>
-  <tr valign="top"><td class="table_header_column"><fmt:message key="facility_name" bundle="${resword}"/>:</td><td class="table_cell">
-  <c:out value="${siteToView.facilityName}"/>&nbsp;
   </td></tr>
 
   <tr valign="top"><td class="table_header_column"><fmt:message key="facility_city" bundle="${resword}"/>:</td><td class="table_cell">
@@ -215,72 +200,72 @@
   <c:forEach var="config" items="${siteToView.studyParameters}">
    <c:choose>
   
-	<c:when test="${config.parameter.handle=='interviewerNameRequired'}">
-		   <tr valign="top"><td class="table_header_column"><fmt:message key="when_entering_data" bundle="${resword}"/></td><td class="table_cell">
-		   
-		   <c:choose>
-		   <c:when test="${   config.value.value == 'yes' }">
-		   <fmt:message key="yes" bundle="${resword}"/>
+  <c:when test="${config.parameter.handle=='interviewerNameRequired'}">
+       <tr valign="top"><td class="table_header_column"><fmt:message key="when_entering_data" bundle="${resword}"/></td><td class="table_cell">
+       
+       <c:choose>
+       <c:when test="${   config.value.value == 'yes' }">
+       <fmt:message key="yes" bundle="${resword}"/>
 
-		   </c:when>
-		   <c:when test="${config.value.value == 'no' }">
-		  			<fmt:message key="no" bundle="${resword}"/>
-		  </c:when>
-		   <c:otherwise>
-		   <fmt:message key="not_used" bundle="${resword}"/>
-		     </c:otherwise>
-		  </c:choose>
-		  </td>
-		  </tr>
-	</c:when>
-	<c:when test="${config.parameter.handle=='interviewerNameDefault'}">
-		  <tr valign="top"><td class="table_header_column"><fmt:message key="interviewer_name_default_as_blank" bundle="${resword}"/></td><td class="table_cell">
-		   <c:choose>
-		   <c:when test="${config.value.value== 'blank'}">
-		    <fmt:message key="blank" bundle="${resword}"/>
+       </c:when>
+       <c:when test="${config.value.value == 'no' }">
+            <fmt:message key="no" bundle="${resword}"/>
+      </c:when>
+       <c:otherwise>
+       <fmt:message key="not_used" bundle="${resword}"/>
+         </c:otherwise>
+      </c:choose>
+      </td>
+      </tr>
+  </c:when>
+  <c:when test="${config.parameter.handle=='interviewerNameDefault'}">
+      <tr valign="top"><td class="table_header_column"><fmt:message key="interviewer_name_default_as_blank" bundle="${resword}"/></td><td class="table_cell">
+       <c:choose>
+       <c:when test="${config.value.value== 'blank'}">
+        <fmt:message key="blank" bundle="${resword}"/>
 
-		   </c:when>
-		   <c:otherwise>
-		   <fmt:message key="pre_populated_from_study_event" bundle="${resword}"/>
-		   </c:otherwise>
-		  </c:choose>
-		  </td>
-		  </tr>
-	</c:when>
-	<c:when test="${config.parameter.handle=='interviewDateRequired'}">
-		  <tr valign="top"><td class="table_header_column"><fmt:message key="interview_date_required" bundle="${resword}"/></td><td class="table_cell">
-		  
-		  <c:choose>
-		   <c:when test="${  config.value.value == 'yes'}">
-		   <fmt:message key="yes" bundle="${resword}"/>
+       </c:when>
+       <c:otherwise>
+       <fmt:message key="pre_populated_from_study_event" bundle="${resword}"/>
+       </c:otherwise>
+      </c:choose>
+      </td>
+      </tr>
+  </c:when>
+  <c:when test="${config.parameter.handle=='interviewDateRequired'}">
+      <tr valign="top"><td class="table_header_column"><fmt:message key="interview_date_required" bundle="${resword}"/></td><td class="table_cell">
+      
+      <c:choose>
+       <c:when test="${  config.value.value == 'yes'}">
+       <fmt:message key="yes" bundle="${resword}"/>
 
-		   </c:when>
-		  <c:when test="${config.value.value == 'no'  }">
-		  			<fmt:message key="no" bundle="${resword}"/>
-		  </c:when>
-		   <c:otherwise>
-		   <fmt:message key="not_used" bundle="${resword}"/>
-		     </c:otherwise>
-		  </c:choose>
-		  </td>
-		  </tr>
+       </c:when>
+      <c:when test="${config.value.value == 'no'  }">
+            <fmt:message key="no" bundle="${resword}"/>
+      </c:when>
+       <c:otherwise>
+       <fmt:message key="not_used" bundle="${resword}"/>
+         </c:otherwise>
+      </c:choose>
+      </td>
+      </tr>
     </c:when>
-	<c:when test="${config.parameter.handle=='interviewDateDefault'}">
-		  <tr valign="top"><td class="table_header_column"><fmt:message key="interview_date_default_as_blank" bundle="${resword}"/></td><td class="table_cell">
-		   <c:choose>
-		   <c:when test="${config.value.value== 'blank'}">
-		   <fmt:message key="blank" bundle="${resword}"/>
+  <c:when test="${config.parameter.handle=='interviewDateDefault'}">
+      <tr valign="top"><td class="table_header_column"><fmt:message key="interview_date_default_as_blank" bundle="${resword}"/></td><td class="table_cell">
+       <c:choose>
+       <c:when test="${config.value.value== 'blank'}">
+       <fmt:message key="blank" bundle="${resword}"/>
 
-		   </c:when>
-		   <c:otherwise>
+       </c:when>
+       <c:otherwise>
 
-		   <fmt:message key="pre_populated_from_study_event" bundle="${resword}"/>
-		   </c:otherwise>
-		  </c:choose>
-		  </td>
-		  </tr>
-	 </c:when>
-	</c:choose>
+       <fmt:message key="pre_populated_from_study_event" bundle="${resword}"/>
+       </c:otherwise>
+      </c:choose>
+      </td>
+      </tr>
+   </c:when>
+  </c:choose>
 
   </c:forEach>
 
@@ -293,7 +278,7 @@
 </div>
 <br>
 
-	<div class="table_title_Manage" style="width:300px;float:left"><fmt:message key="view_site_event_definitions" bundle="${resword}"/></div>
+  <div class="table_title_Manage" style="width:300px;float:left"><fmt:message key="view_site_event_definitions" bundle="${resword}"/></div>
 <div style="float:left;width:8%">
 <!--
    <a href="javascript:openDocWindow('PrintAllSiteEventCRF?siteId=<c:out value="${siteToView.id}"/>')"
@@ -306,16 +291,16 @@
 <c:set var="defCount" value="0"/>
 <c:forEach var="definition" items="${definitions}">
 <c:set var="defCount" value="${defCount+1}"/>
-	&nbsp&nbsp&nbsp&nbsp<b><a href="javascript:leftnavExpand('sed<c:out value="${defCount}"/>');">
+  &nbsp&nbsp&nbsp&nbsp<b><a href="javascript:leftnavExpand('sed<c:out value="${defCount}"/>');">
         <img id="excl_sed<c:out value="${defCount}"/>" src="images/bt_Expand.gif" border="0"> <c:out value="${definition.name}"/></b></a>
-		<c:choose>
-		<c:when test="${idToSort>0 && idToSort == definition.id}">
-			<div id="sed<c:out value="${defCount}"/>" style="display: all">
-		</c:when>
-		<c:otherwise>
-			<div id="sed<c:out value="${defCount}"/>" style="display: none">
-		</c:otherwise>
-		</c:choose>
+    <c:choose>
+    <c:when test="${idToSort>0 && idToSort == definition.id}">
+      <div id="sed<c:out value="${defCount}"/>" style="display: all">
+    </c:when>
+    <c:otherwise>
+      <div id="sed<c:out value="${defCount}"/>" style="display: none">
+    </c:otherwise>
+    </c:choose>
 
 <div style="width: 600px">
 <div class="box_T"><div class="box_L"><div class="box_R"><div class="box_B"><div class="box_TL"><div class="box_TR"><div class="box_BL"><div class="box_BR">
@@ -406,16 +391,16 @@
 
     <c:choose>
     <c:when test="${fn:length(crf.selectedVersionIds)>0}">
-		<c:set var="selectedVersionNames" value="${crf.selectedVersionNames}"/>
+    <c:set var="selectedVersionNames" value="${crf.selectedVersionNames}"/>
     </c:when>
     <c:otherwise>
-		<c:set var="selectedVersionNames" value=""/>
-		<c:forEach var="v" items="${crf.versions}">
-			<c:set var="selectedVersionNames" value="${selectedVersionNames}${v.name},"/>
-		</c:forEach>
-		<c:set var="selectedVersionNames" value="${fn:substring(selectedVersionNames,0,fn:length(selectedVersionNames)-1)}"/>
-	</c:otherwise>
-	</c:choose>
+    <c:set var="selectedVersionNames" value=""/>
+    <c:forEach var="v" items="${crf.versions}">
+      <c:set var="selectedVersionNames" value="${selectedVersionNames}${v.name},"/>
+    </c:forEach>
+    <c:set var="selectedVersionNames" value="${fn:substring(selectedVersionNames,0,fn:length(selectedVersionNames)-1)}"/>
+  </c:otherwise>
+  </c:choose>
 
 
     <td class="table_cell">
@@ -495,7 +480,7 @@
    <td class="table_cell"><c:out value="${crf.status.name}"/></td>
    <td class="table_cell">
      <table border="0" cellpadding="0" cellspacing="0">
-	  <tr>
+    <tr>
         <td>
                    <a href="ViewCRF?crfId=<c:out value="${crf.crfId}"/>"
                  onMouseDown="javascript:setImage('bt_View1','images/bt_View_d.gif');"
@@ -503,9 +488,9 @@
                 name="bt_View1" src="images/bt_View.gif" border="0" alt="<fmt:message key="view" bundle="${resword}"/>" title="<fmt:message key="view" bundle="${resword}"/>" align="left" hspace="6"></a>
 
         </td>
-		
-	  </tr>
-	 </table>
+    
+    </tr>
+   </table>
    </td>
    </tr>
    <c:set var="prevCrf" value="${crf}"/>

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/viewSite.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/viewSite.jsp
@@ -313,9 +313,6 @@
     <tr valign="top"><td class="table_header_column"><fmt:message key="oid" bundle="${resword}"/>:</td><td class="table_cell">
   <c:out value="${definition.oid}"/>
    </td></tr>
-  <tr valign="top"><td class="table_header_column"><fmt:message key="description" bundle="${resword}"/>:</td><td class="table_cell">
-  <c:out value="${definition.description}"/>&nbsp;
-  </td></tr>
 
  <tr valign="top"><td class="table_header_column"><fmt:message key="repeating" bundle="${resword}"/>:</td><td class="table_cell">
   <c:choose>
@@ -328,9 +325,6 @@
     <c:out value="${definition.type}"/>
    </td></tr>
 
-  <tr valign="top"><td class="table_header_column"><fmt:message key="category" bundle="${resword}"/>:</td><td class="table_cell">
-  <c:out value="${definition.category}"/>&nbsp;
-  </td></tr>
   </table>
   </div>
 </div></div></div></div></div></div></div></div>

--- a/web/src/main/webapp/WEB-INF/jsp/submit/addNewSubjectExpressNew.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/addNewSubjectExpressNew.jsp
@@ -70,8 +70,6 @@
     </c:if>
 </c:forEach>
 
-<link type="text/css" rel="stylesheet" href="<c:url value="/style.css"/>"/>
-
 <form name="subjectForm" action="AddNewSubject" method="post">
 <input type="hidden" name="subjectOverlay" value="true">
 


### PR DESCRIPTION
View CRF Details page (in Bridge)
Remove Description field
before:
![view crf details page in bridge remove description field_before](https://user-images.githubusercontent.com/16472454/31811957-9b19f038-b5ab-11e7-9132-f3deaa5c9e5e.png)
after:
![view crf details page in bridge remove description field_after](https://user-images.githubusercontent.com/16472454/31811963-a35ff0d0-b5ab-11e7-8dd3-2bdf319debef.png)

Versions Table:
Remove Description and Revision Notes columns
before:
![versions table remove description and revision notes columns_before](https://user-images.githubusercontent.com/16472454/31811986-b6b2cdce-b5ab-11e7-89da-bc20f8d5d122.png)
after:
![screenshot from 2017-10-20 16-34-25](https://user-images.githubusercontent.com/16472454/31814673-903c05b2-b5b4-11e7-9e5d-2ca45c4649d2.png)


Items Table
Remove Description column
![items before](https://user-images.githubusercontent.com/16472454/31812017-d541d9b0-b5ab-11e7-8b58-f6a8a4d580be.png)
after:
![items_after](https://user-images.githubusercontent.com/16472454/31812061-fbf49f16-b5ab-11e7-8e02-261f26acebc4.png)

The repeating event “x2” should be made a hyperlink and placed closer to the visit status icon.
![x2](https://user-images.githubusercontent.com/16472454/31812119-2c293ee4-b5ac-11e7-991b-5e18799b4907.png)

Data Specialist, Data Entry Person, Investigator, Clinical Research Coordinator - These roles get the Subject Matrix on login. Can we expand the Info pane on the left bar? Without this pane expanded, the user doesn’t see the study name, status, etc. We can probably just have it open on page load all the time for all users.
![ds](https://user-images.githubusercontent.com/16472454/31812191-65680d02-b5ac-11e7-9476-7a6111847475.png)









