### PR TITLE
Tasks > Monitor and Manage Data > View Study:

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/controller/StudyController.java
+++ b/web/src/main/java/org/akaza/openclinica/controller/StudyController.java
@@ -603,6 +603,7 @@ public class StudyController {
         study.setDatePlannedEnd(parameters.endDate);
         study.setExpectedTotalEnrollment(parameters.expectedTotalEnrollment);
         study.setProtocolType(parameters.studyType.toLowerCase());
+        study.setProtocolDescription(parameters.description);
         if(study.getStatus() != null){
             study.setOldStatusId(study.getStatus().getCode());
         }

--- a/web/src/main/java/org/akaza/openclinica/service/LiquibaseOnDemandServiceImpl.java
+++ b/web/src/main/java/org/akaza/openclinica/service/LiquibaseOnDemandServiceImpl.java
@@ -81,6 +81,8 @@ public class LiquibaseOnDemandServiceImpl implements LiquibaseOnDemandService {
             schemaStudy.setDatePlannedEnd(studyInfoObject.getStudy().getDatePlannedEnd());
             schemaStudy.setExpectedTotalEnrollment((studyInfoObject.getStudy().getExpectedTotalEnrollment()));
             schemaStudy.setProtocolType(studyInfoObject.getStudy().getProtocolType());
+            schemaStudy.setProtocolDescription(studyInfoObject.getStudy().getProtocolDescription());
+            schemaStudy.setPhase(studyInfoObject.getStudy().getPhase());
 
             schemaServiceDao.setConnectionSchemaName(studyInfoObject.getSchema());
             studyDao.getCurrentSession().clear();

--- a/web/src/main/resources/org/akaza/openclinica/i18n/words.properties
+++ b/web/src/main/resources/org/akaza/openclinica/i18n/words.properties
@@ -3148,3 +3148,9 @@ nav_sites = Sites
 update_event_definitions_for_site = Update event definitions for site
 form_title = Form Title
 closed_modified_message = Data changed after query was closed
+
+PHASEI = Phase I
+PHASEII = Phase II
+PHASEIII = Phase III
+PHASEIV = Phase IV
+OTHER_NON_IND = Other/non-IND

--- a/web/src/main/webapp/WEB-INF/jsp/admin/viewFullStudy.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/viewFullStudy.jsp
@@ -101,7 +101,7 @@
   <c:out value="${studyToView.principalInvestigator}"/>
   </td></tr>
   <tr valign="top"><td class="table_header_column"><fmt:message key="brief_summary" bundle="${resword}"/>:</td><td class="table_cell">
-  <c:out value="${studyToView.name}"/>&nbsp;
+  <c:out value="${studyToView.protocolDescription}"/>&nbsp;
   </td></tr>
 
   <tr valign="top"><td class="table_header_column"><fmt:message key="owner" bundle="${resword}"/>:</td><td class="table_cell">
@@ -129,7 +129,7 @@
 <div class="tablebox_center">
 <table border="0" cellpadding="0" cellspacing="0" width="100%">
   <tr valign="top"><td class="table_header_column"><a href="http://prsinfo.clinicaltrials.gov/definitions.html#BriefTitle" target="def_win" onClick="openDefWindow('http://prsinfo.clinicaltrials.gov/definitions.html#BriefTitle'); return false;"><fmt:message key="brief_title" bundle="${resword}"/></a>:</td><td class="table_cell">
-  <c:out value="${studyToView.summary}"/>
+  <c:out value="${studyToView.name}"/>
   </td></tr>
 
   <tr valign="top"><td class="table_header_column"><a href="http://prsinfo.clinicaltrials.gov/definitions.html#PrimaryId" target="def_win" onClick="openDefWindow('http://prsinfo.clinicaltrials.gov/definitions.html#PrimaryId'); return false;"><fmt:message key="unique_protocol_ID" bundle="${resword}"/></a>:</td><td class="table_cell">
@@ -141,7 +141,7 @@
   </td></tr>
 
   <tr valign="top"><td class="table_header_column"><a href="http://prsinfo.clinicaltrials.gov/definitions.html#BriefSummary" target="def_win" onClick="openDefWindow('http://prsinfo.clinicaltrials.gov/definitions.html#BriefSummary'); return false;"><fmt:message key="brief_summary" bundle="${resword}"/></a>:</td><td class="table_cell">
-  <c:out value="${studyToView.summary}"/>
+  <c:out value="${studyToView.protocolDescription}"/>
   </td></tr>
   </table>
 </div>
@@ -161,7 +161,7 @@
 <div class="tablebox_center">
 <table border="0" cellpadding="0" cellspacing="0" width="100%">
  <tr valign="top"><td class="table_header_column"><fmt:message key="study_phase" bundle="${resword}"/>:</td><td class="table_cell">
-  <c:out value="${studyToView.phase}"/>
+  <fmt:message key="${studyToView.phase}" bundle="${resword}"/>
   </td></tr>
 
  <tr valign="top"><td class="table_header_column"><a href="http://prsinfo.clinicaltrials.gov/definitions.html#StudyType" target="def_win" onClick="openDefWindow('http://prsinfo.clinicaltrials.gov/definitions.html#StudyType'); return false;"><fmt:message key="protocol_type" bundle="${resword}"/></a>:</td><td class="table_cell">

--- a/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
@@ -295,10 +295,16 @@
         <div class="taskGroup"><fmt:message key="nav_submit_data" bundle="${resword}"/></div>
         <div class="taskLeftColumn">
             <div class="taskLink"><a href="${urlPrefix}ListStudySubjects"><fmt:message key="nav_subject_matrix" bundle="${resword}"/></a></div>
-            <c:if test="${study.status.available}">
-                <div class="taskLink"><a href="javascript:;" id="navAddSubjectSD"><fmt:message key="nav_add_subject" bundle="${resword}"/></a></div>
-            </c:if>
-            <div class="taskLink"><a href="${urlPrefix}ViewNotes?module=submit"><fmt:message key="queries" bundle="${resword}"/></a></div>
+            <c:choose>
+                <c:when test="${study.status.available}">
+                    <div class="taskLink"><a href="javascript:;" id="navAddSubjectSD"><fmt:message key="nav_add_subject" bundle="${resword}"/></a></div>
+                    <div class="taskLink"><a href="${urlPrefix}ViewNotes?module=submit"><fmt:message key="queries" bundle="${resword}"/></a></div>
+                </c:when>
+                <c:otherwise>
+                    <div class="taskLink"><a href="${urlPrefix}ViewNotes?module=submit"><fmt:message key="queries" bundle="${resword}"/></a></div>
+                    <div class="taskLink">&nbsp;</div>
+                </c:otherwise>
+            </c:choose>
         </div>
         <div class="taskRightColumn">
             <c:if test="${!study.status.frozen && !study.status.locked}">


### PR DESCRIPTION
- Brief Summary (in Overview and Section A) should show the study Description defined in Study Manager.
- Section B - Study Phase - Show the Display Text that is visible in the dropdown in Study Manager (example: “Phase I” not “PHASEI”)
![screenshot from 2017-10-23 15-36-50](https://user-images.githubusercontent.com/13865076/31879467-0f0bdb4e-b810-11e7-9f77-cdbb1af7a6d4.png)

Note:
I found out that description from study-manager not saved yet to database bridge so I save it to parameter protocolDescription.(let me know if that not proper place for it)