### PR TITLE
OC-8388 Queries table

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/service/managestudy/ViewNotesFilterCriteria.java
+++ b/core/src/main/java/org/akaza/openclinica/service/managestudy/ViewNotesFilterCriteria.java
@@ -54,6 +54,7 @@ public class ViewNotesFilterCriteria {
         FILTER_BY_TABLE_COLUMN.put("entityValue", "value");
         FILTER_BY_TABLE_COLUMN.put("discrepancyNoteBean.entityType", "entity_type");
         FILTER_BY_TABLE_COLUMN.put("discrepancyNoteBean.description", "description");
+        FILTER_BY_TABLE_COLUMN.put("discrepancyNoteBean.detailedNotes", "detailed_notes");
         FILTER_BY_TABLE_COLUMN.put("discrepancyNoteBean.user", "user");
     }
 

--- a/core/src/main/resources/queries/postgres/viewnotes.properties
+++ b/core/src/main/resources/queries/postgres/viewnotes.properties
@@ -8,21 +8,21 @@ findAllDiscrepancyNotes.filter.studyHideCrf=and (study_hide_crf = false or study
 
 findAllDiscrepancyNotes.filter.siteHideCrf=and site_hide_crf is not true   and study_hide_crf is not true 
 
-findAllDiscrepancyNotes.filter.label=and label like :label
+findAllDiscrepancyNotes.filter.label=and LOWER(label) like LOWER(:label)
 findAllDiscrepancyNotes.filter.discrepancy_note_type_id=and discrepancy_note_type_id in ( :discrepancy_note_type_id )
 findAllDiscrepancyNotes.filter.resolution_status_id=and resolution_status_id in ( :resolution_status_id )
-findAllDiscrepancyNotes.filter.site_id=and site_id like :site_id
+findAllDiscrepancyNotes.filter.site_id=and LOWER(site_id) like LOWER(:site_id)
 findAllDiscrepancyNotes.filter.date_created=and date(date_created) = :date_created
 findAllDiscrepancyNotes.filter.date_updated=and date(date_updated) = :date_updated
 findAllDiscrepancyNotes.filter.days=and days = :days
 findAllDiscrepancyNotes.filter.age=and age = :age
-findAllDiscrepancyNotes.filter.event_name=and event_name like :event_name
-findAllDiscrepancyNotes.filter.crf_name=and crf_name like :crf_name
-findAllDiscrepancyNotes.filter.entity_name=and entity_name like :entity_name
-findAllDiscrepancyNotes.filter.value=and value like :value
-findAllDiscrepancyNotes.filter.entity_type=and entity_type like :entity_type
-findAllDiscrepancyNotes.filter.description=and description like :description
-findAllDiscrepancyNotes.filter.user=and (user_name like :user or first_name like :user or last_name like :user)
+findAllDiscrepancyNotes.filter.event_name=and LOWER(event_name) like LOWER(:event_name)
+findAllDiscrepancyNotes.filter.crf_name=and LOWER(crf_name) like LOWER(:crf_name)
+findAllDiscrepancyNotes.filter.entity_name=and LOWER(entity_name) like LOWER(:entity_name)
+findAllDiscrepancyNotes.filter.value=and LOWER(value) like LOWER(:value)
+findAllDiscrepancyNotes.filter.entity_type=and LOWER(entity_type) like LOWER(:entity_type)
+findAllDiscrepancyNotes.filter.description=and LOWER(description) like LOWER(:description)
+findAllDiscrepancyNotes.filter.user=and (LOWER(user_name) like LOWER(:user) or LOWER(first_name) like LOWER(:user) or LOWER(last_name) like LOWER(:user))
 
 findAllDiscrepancyNotes.orderby=order by
 

--- a/core/src/main/resources/queries/postgres/viewnotes.properties
+++ b/core/src/main/resources/queries/postgres/viewnotes.properties
@@ -23,6 +23,7 @@ findAllDiscrepancyNotes.filter.value=and LOWER(value) like LOWER(:value)
 findAllDiscrepancyNotes.filter.entity_type=and LOWER(entity_type) like LOWER(:entity_type)
 findAllDiscrepancyNotes.filter.description=and LOWER(description) like LOWER(:description)
 findAllDiscrepancyNotes.filter.user=and (LOWER(user_name) like LOWER(:user) or LOWER(first_name) like LOWER(:user) or LOWER(last_name) like LOWER(:user))
+findAllDiscrepancyNotes.filter.detailed_notes=and LOWER(detailed_notes) like LOWER(:detailed_notes)
 
 findAllDiscrepancyNotes.orderby=order by
 

--- a/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableFactory.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableFactory.java
@@ -124,7 +124,7 @@ public class ListNotesTableFactory extends AbstractTableFactory {
         configureColumn(row.getColumn("entityName"), resword.getString("entity_name"), new EntityNameCellEditor(), null, true, false);
         configureColumn(row.getColumn("entityValue"), resword.getString("entity_value"), null, null, true, false);
         configureColumn(row.getColumn("discrepancyNoteBean.description"), resword.getString("description"), null, null, true, false);
-        configureColumn(row.getColumn("discrepancyNoteBean.detailedNotes"), resword.getString("detailed_notes"), null, null, false, false);
+        configureColumn(row.getColumn("discrepancyNoteBean.detailedNotes"), resword.getString("detailed_notes"), null, null, true, false);
         configureColumn(row.getColumn("numberOfNotes"), resword.getString("of_notes"), null, null, false, false);
         configureColumn(row.getColumn("discrepancyNoteBean.user"), resword.getString("assigned_user"), new AssignedUserCellEditor(), null, true, false);
         configureColumn(row.getColumn("discrepancyNoteBean.resolutionStatus"), resword.getString("resolution_status"), new ResolutionStatusCellEditor(),


### PR DESCRIPTION
- Queries table - Add Queries to Event End Date or Start Date and Subject Enrollment Date or Date of Birth. Go to the Queries table. Filter the table by the Item Name column and type “Date”. No results are returned even though this is an exact case match for the event/subject items. Filter by “date”. This returns all of the rows for the event/subject queries even though it is not a case match for the event/subject items. To match the behavior of other columns, filters should only return results that match the case entered (so “Date” should return each of the event/subject queries and “date” should not return any of them. See OC-8388

Note: 
- Filter incasensitive work fine on all column except for "Site ID" and "Item Type" somehow it failed to show any row after rendering(I still find the row on debugging but not show any after tf.render()). This happen if using partial value filter only, work fine using full value filter.  