### PR TITLE
Edit Manual Testing/Bug Fixing - Misc Cosmetic Issues (27/10/17 progress)

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableFactory.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableFactory.java
@@ -108,7 +108,7 @@ public class ListNotesTableFactory extends AbstractTableFactory {
 
         tableFacade.setColumnProperties("studySubject.label", "discrepancyNoteBean.resolutionStatus", "siteId",
                 "discrepancyNoteBean.createdDate", "discrepancyNoteBean.updatedDate", "age", "days", "eventName", "eventStartDate", "crfName", "crfStatus",
-                "entityName", "entityValue", "discrepancyNoteBean.entityType", "discrepancyNoteBean.description", "discrepancyNoteBean.detailedNotes",
+                "entityName", "entityValue", "discrepancyNoteBean.entityType", "discrepancyNoteBean.detailedNotes",
                 "numberOfNotes", "discrepancyNoteBean.user", "discrepancyNoteBean.owner", "actions");
         Row row = tableFacade.getTable().getRow();
         configureColumn(row.getColumn("studySubject.label"), resword.getString("study_subject_ID"), null, null, true, true);
@@ -123,7 +123,6 @@ public class ListNotesTableFactory extends AbstractTableFactory {
         configureColumn(row.getColumn("crfStatus"), resword.getString("CRF_status"), null, null, false, false);
         configureColumn(row.getColumn("entityName"), resword.getString("entity_name"), new EntityNameCellEditor(), null, true, false);
         configureColumn(row.getColumn("entityValue"), resword.getString("entity_value"), null, null, true, false);
-        configureColumn(row.getColumn("discrepancyNoteBean.description"), resword.getString("description"), null, null, true, false);
         configureColumn(row.getColumn("discrepancyNoteBean.detailedNotes"), resword.getString("detailed_notes"), null, null, true, false);
         configureColumn(row.getColumn("numberOfNotes"), resword.getString("of_notes"), null, null, false, false);
         configureColumn(row.getColumn("discrepancyNoteBean.user"), resword.getString("assigned_user"), new AssignedUserCellEditor(), null, true, false);

--- a/web/src/main/resources/org/akaza/openclinica/i18n/notes.properties
+++ b/web/src/main/resources/org/akaza/openclinica/i18n/notes.properties
@@ -55,7 +55,7 @@ browse_by_SED = Browse by Study Event Definition
 
 browse_by_subject = Browse by Subject
 
-but_no_role = but no role.
+but_no_role =  but you have not been assigned a role.
 
 can_download_blank_CRF_excel = You can download a blank OpenClinica CRF Excel spreadsheet template\u0009
 

--- a/web/src/main/webapp/WEB-INF/jsp/admin/showCRFRow.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/showCRFRow.jsp
@@ -95,7 +95,7 @@
       <table border="0" cellpadding="0" cellspacing="0">
         <tr>
           <td>
-            <a href="EnketoFormServlet?formLayoutId=<c:out value="${version.id}"/>&studyEventId=<c:out value="0"/>&eventCrfId=<c:out value="0"/>&originatingPage=<c:out value="${originatingPage}"/>&mode=<c:out value="view"/>"><span
+            <a href="EnketoFormServlet?formLayoutId=<c:out value="${version.id}"/>&studyEventId=<c:out value="0"/>&eventCrfId=<c:out value="0"/>&originatingPage=<c:out value="${originatingPage}"/>&mode=<c:out value="edit"/>"><span
               name="bt_View1" class="icon icon-search" border="0" alt="<fmt:message key="view" bundle="${resword}"/>" title="<fmt:message key="view" bundle="${resword}"/>" align="left" hspace="6"></a>
           </td>
           <c:if test="${version.status.available && userBean.sysAdmin && module=='admin'}">

--- a/web/src/main/webapp/WEB-INF/jsp/admin/viewCRF.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/viewCRF.jsp
@@ -110,7 +110,7 @@
                             <tr>
                                 <td>
                                    
-                                    <a href="EnketoFormServlet?formLayoutId=<c:out value="${version.id}"/>&studyEventId=<c:out value="0"/>&eventCrfId=<c:out value="0"/>&originatingPage=<c:out value="${originatingPage}"/>&mode=<c:out value="view"/>"/><span
+                                    <a href="EnketoFormServlet?formLayoutId=<c:out value="${version.id}"/>&studyEventId=<c:out value="0"/>&eventCrfId=<c:out value="0"/>&originatingPage=<c:out value="${originatingPage}"/>&mode=<c:out value="edit"/>"/><span
                                             name="bt_View1" class="icon icon-search" border="0" alt="<fmt:message key="view" bundle="${resword}"/>" title="<fmt:message key="view" bundle="${resword}"/>" align="left" hspace="6"></a>
                                 </td>
                                 <td>

--- a/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
@@ -371,6 +371,18 @@
             return false;
         });
     });
+
+    //close dropdown when click outside
+    clickOutside = document.getElementById("subnav_Tasks");
+    clickOutside.addEventListener("click",     function(action){action.stopPropagation()},true);
+    addEventListener("click", function() {clickOutside.style.display="none"},false);
+    
+    //close dropdown using esc
+    $(document).keyup(function(e) {
+        if (e.keyCode == 27) { // escape key maps to keycode `27`
+            clickOutside.style.display="none";
+        }
+    });
 </script>
 
 <div id="navAddSubjectForm" style="display: none">

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/viewStudySubject.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/viewStudySubject.jsp
@@ -76,7 +76,7 @@
 
 <h1>   
     <span class="title_manage">
-        <fmt:message key="view_subjects_in" bundle="${restext}"/> <c:out value="${study.name}"/>
+        <fmt:message key="view_subject2" bundle="${resword}"/><c:out value="${studySub.label}"/>
     </span>
 </h1>
 <br/>


### PR DESCRIPTION
Login as a new user. Then remove that user from all studies. Then login to Bridge as that user.  You’ll see a screen like this:
Change the text from “Your current active study is [active study], but no role.” to “Your current active study is [active study], but you have not been assigned a role.”.
before:
![login as new user before](https://user-images.githubusercontent.com/16472454/32094447-f7cc08a6-bb29-11e7-8147-018d2df290de.png)
after:
![login as new user after](https://user-images.githubusercontent.com/16472454/32094456-fecae154-bb29-11e7-91a5-94211b98b7bd.png)

 I'm still seeing the description column on cust7.dev-runtime. The Detailed Notes filter is working now, though. The Detailed Notes filter is working now, though.
![queries table-remove description](https://user-images.githubusercontent.com/16472454/32094481-0e9db188-bb2a-11e7-8235-443befc383b0.png)

View Subject Page
Page title is wrong. It now says “Subject Matrix for STUDYNAME”. It needs to be changed back to “View Subject: SUBJECTID”
![view subject page](https://user-images.githubusercontent.com/16472454/32094501-2197b02c-bb2a-11e7-8bc3-501f7be4bba9.png)



