### PR TITLE
Queries table - Problem filtering translate value

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/service/managestudy/ViewNotesFilterCriteria.java
+++ b/core/src/main/java/org/akaza/openclinica/service/managestudy/ViewNotesFilterCriteria.java
@@ -83,6 +83,9 @@ public class ViewNotesFilterCriteria {
                 value = discrepancyNoteTypeDecoder.get(value);
             } else if (filterName.equals("resolution_status_id")) {
                 value = resolutionTypeDecoder.get(value);
+            } else if (filterName.equals("entity_name")) {
+                // translate value need to replace space with _
+                value = value.replace(" ", "_");
             }
 
             criteria.getFilters().put(filterName, processValue(filterName, value, df));
@@ -108,6 +111,9 @@ public class ViewNotesFilterCriteria {
                     value = discrepancyNoteTypeDecoder.get(value);
                 } else if (filterName.equals("resolution_status_id")) {
                     value = resolutionTypeDecoder.get(value);
+                } else if (filterName.equals("entity_name")) {
+                    // translate value need to replace space with _
+                    value = value.replace(" ", "_");
                 }
                 criteria.getFilters().put(filterName, processValue(filterName, value, df));
             }


### PR DESCRIPTION
- Queries table - Add Queries to Event End Date and Start Date. Go to the Queries table. Filter the table by the Item Name column and type “Date”. End Date and Start Date are returned. Filter by “End”. End Date is returned. Filter by “End Date” (which is an exact match for what is displayed) and nothing is returned. I expect this filter should still return all rows that match “End Date”.