### PR TITLE
View CRF in preview mode

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/service/crfdata/xform/EnketoAPI.java
+++ b/core/src/main/java/org/akaza/openclinica/service/crfdata/xform/EnketoAPI.java
@@ -38,6 +38,7 @@ public class EnketoAPI {
     public static final String SINGLE_ITEM_FLAVOR = "-single_item";
     public static final String VIEW_MODE = "view";
     public static final String EDIT_MODE = "edit";
+    public static final String PREVIEW_MODE = "preview";
 
     /*
      * SURVEY : Initial Data Entry
@@ -116,7 +117,10 @@ public class EnketoAPI {
             // https://jira.openclinica.com/browse/OC-8279 Study Director edits XForms.
         } else if (mode.equals(EDIT_MODE) && (role == Role.STUDYDIRECTOR || role == Role.COORDINATOR)) {
             eURL = new URL(enketoURL + SURVEY_WRITABLE_DN_CLOSE_BUTTON);
+        } else if (mode.equals(PREVIEW_MODE)) {
+            eURL = new URL(enketoURL + SURVEY_PREVIEW_MODE);
         }
+
         String myUrl = null;
         EnketoURLResponse response = registerAndGetURL(eURL, crfOID);
         if (response != null) {
@@ -124,6 +128,8 @@ public class EnketoAPI {
                 myUrl = response.getSingle_fieldsubmission_iframe_url();
             } else if (response.getView_iframe_url() != null) {
                 myUrl = response.getView_iframe_url();
+            } else if (response.getPreview_url() != null) {
+                myUrl = response.getPreview_url();
             }
 
             if (enketoURL.toLowerCase().startsWith("https") && !myUrl.toLowerCase().startsWith("https")) {

--- a/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableFactory.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableFactory.java
@@ -106,10 +106,25 @@ public class ListNotesTableFactory extends AbstractTableFactory {
     @Override
     protected void configureColumns(TableFacade tableFacade, Locale locale) {
 
-        tableFacade.setColumnProperties("studySubject.label", "discrepancyNoteBean.resolutionStatus", "siteId",
-                "discrepancyNoteBean.createdDate", "discrepancyNoteBean.updatedDate", "age", "days", "eventName", "eventStartDate", "crfName", "crfStatus",
-                "entityName", "entityValue", "discrepancyNoteBean.entityType", "discrepancyNoteBean.detailedNotes",
-                "numberOfNotes", "discrepancyNoteBean.user", "discrepancyNoteBean.owner", "actions");
+        tableFacade.setColumnProperties("studySubject.label",
+                "discrepancyNoteBean.createdDate",
+                "discrepancyNoteBean.resolutionStatus",
+                "siteId",
+                "discrepancyNoteBean.updatedDate",
+                "age",
+                "days",
+                "eventName",
+                "eventStartDate",
+                "crfName",
+                "crfStatus",
+                "discrepancyNoteBean.detailedNotes",
+                "numberOfNotes",
+                "discrepancyNoteBean.user",
+                "entityName",
+                "entityValue",
+                "discrepancyNoteBean.entityType",
+                "actions");
+
         Row row = tableFacade.getTable().getRow();
         configureColumn(row.getColumn("studySubject.label"), resword.getString("study_subject_ID"), null, null, true, true);
         configureColumn(row.getColumn("siteId"), resword.getString("site_id"), null, null, true, false);
@@ -117,30 +132,31 @@ public class ListNotesTableFactory extends AbstractTableFactory {
                 true);
         configureColumn(row.getColumn("discrepancyNoteBean.updatedDate"), resword.getString("date_updated"), new DateCellEditor(getDateFormat()), null, true,
                 false);
+        configureColumn(row.getColumn("age"), resword.getString("days_open"), null, null);
+        configureColumn(row.getColumn("days"), resword.getString("days_since_updated"), null, null);
         configureColumn(row.getColumn("eventStartDate"), resword.getString("event_date"), new DateCellEditor(getDateFormat()), null, false, false);
         configureColumn(row.getColumn("eventName"), resword.getString("event_name"), null, null, true, false);
         configureColumn(row.getColumn("crfName"), resword.getString("CRF"), null, null, true, false);
         configureColumn(row.getColumn("crfStatus"), resword.getString("CRF_status"), null, null, false, false);
         configureColumn(row.getColumn("entityName"), resword.getString("entity_name"), new EntityNameCellEditor(), null, true, false);
         configureColumn(row.getColumn("entityValue"), resword.getString("entity_value"), null, null, true, false);
+        configureColumn(row.getColumn("discrepancyNoteBean.resolutionStatus"), resword.getString("resolution_status"), new ResolutionStatusCellEditor(),
+                resolutionStatusDropdown, true, false);
         configureColumn(row.getColumn("discrepancyNoteBean.detailedNotes"), resword.getString("detailed_notes"), null, null, true, false);
         configureColumn(row.getColumn("numberOfNotes"), resword.getString("of_notes"), null, null, false, false);
         configureColumn(row.getColumn("discrepancyNoteBean.user"), resword.getString("assigned_user"), new AssignedUserCellEditor(), null, true, false);
-        configureColumn(row.getColumn("discrepancyNoteBean.resolutionStatus"), resword.getString("resolution_status"), new ResolutionStatusCellEditor(),
-                resolutionStatusDropdown, true, false);
         configureColumn(row.getColumn("discrepancyNoteBean.entityType"), resword.getString("entity_type"), null, null, true, false);
-        configureColumn(row.getColumn("discrepancyNoteBean.owner"), resword.getString("owner"), new OwnerCellEditor(), null, false, false);
+
         String actionsHeader = resword.getString("actions") + "&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;";
         configureColumn(row.getColumn("actions"), actionsHeader, new ActionsCellEditor(), new DefaultActionsEditor(locale), true, false);
-        configureColumn(row.getColumn("age"), resword.getString("days_open"), null, null);
-        configureColumn(row.getColumn("days"), resword.getString("days_since_updated"), null, null);
     }
+
 
     @Override
     public void configureTableFacadePostColumnConfiguration(TableFacade tableFacade) {
         ListNotesTableToolbar toolbar = new ListNotesTableToolbar(showMoreLink);
         toolbar.setStudyHasDiscNotes(studyHasDiscNotes);
-        toolbar.setDiscNoteType(discNoteType);
+
         toolbar.setResolutionStatus(resolutionStatus);
         toolbar.setModule(module);
         toolbar.setResword(resword);
@@ -222,12 +238,10 @@ public class ListNotesTableFactory extends AbstractTableFactory {
             h.put("crfStatus", discrepancyNoteBean.getCrfStatus());
             h.put("entityName", discrepancyNoteBean.getEntityName());
             h.put("entityValue", discrepancyNoteBean.getEntityValue());
-            h.put("discrepancyNoteBean", discrepancyNoteBean);
             h.put("discrepancyNoteBean.detailedNotes", discrepancyNoteBean.getDetailedNotes());
             h.put("numberOfNotes", discrepancyNoteBean.getNumChildren());
             h.put("discrepancyNoteBean.user", discrepancyNoteBean.getAssignedUser());
             h.put("discrepancyNoteBean.entityType", discrepancyNoteBean.getEntityType());
-            h.put("discrepancyNoteBean.owner", discrepancyNoteBean.getOwner());
 
             theItems.add(h);
             setStudyHasDiscNotes(true);

--- a/web/src/main/webapp/WEB-INF/jsp/admin/showCRFRow.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/showCRFRow.jsp
@@ -95,7 +95,7 @@
       <table border="0" cellpadding="0" cellspacing="0">
         <tr>
           <td>
-            <a href="EnketoFormServlet?formLayoutId=<c:out value="${version.id}"/>&studyEventId=<c:out value="0"/>&eventCrfId=<c:out value="0"/>&originatingPage=<c:out value="${originatingPage}"/>&mode=<c:out value="edit"/>"><span
+            <a href="EnketoFormServlet?formLayoutId=<c:out value="${version.id}"/>&studyEventId=<c:out value="0"/>&eventCrfId=<c:out value="0"/>&originatingPage=<c:out value="${originatingPage}"/>&mode=preview" target="_blank"><span
               name="bt_View1" class="icon icon-search" border="0" alt="<fmt:message key="view" bundle="${resword}"/>" title="<fmt:message key="view" bundle="${resword}"/>" align="left" hspace="6"></a>
           </td>
           <c:if test="${version.status.available && userBean.sysAdmin && module=='admin'}">

--- a/web/src/main/webapp/WEB-INF/jsp/admin/viewCRF.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/viewCRF.jsp
@@ -110,7 +110,7 @@
                             <tr>
                                 <td>
                                    
-                                    <a href="EnketoFormServlet?formLayoutId=<c:out value="${version.id}"/>&studyEventId=<c:out value="0"/>&eventCrfId=<c:out value="0"/>&originatingPage=<c:out value="${originatingPage}"/>&mode=<c:out value="edit"/>"/><span
+                                    <a href="EnketoFormServlet?formLayoutId=<c:out value="${version.id}"/>&studyEventId=<c:out value="0"/>&eventCrfId=<c:out value="0"/>&originatingPage=<c:out value="${originatingPage}"/>&mode=preview" target="_blank"><span
                                             name="bt_View1" class="icon icon-search" border="0" alt="<fmt:message key="view" bundle="${resword}"/>" title="<fmt:message key="view" bundle="${resword}"/>" align="left" hspace="6"></a>
                                 </td>
                                 <td>


### PR DESCRIPTION
- View CRF Details page (in Bridge)
    Versions Table: Change View icon to open Preview view
- Manage Case Report Forms page - When you click the view button for a Form version (not the first view link for the top level form), it should open the form in Preview mode like how it opens when you click Preview in Study Designer. Right now it is opening it in Read-only mode.
![screenshot from 2017-10-28 19-42-15](https://user-images.githubusercontent.com/13865076/32134109-624791f2-bc18-11e7-9607-019d4a831804.png)

NOTE:
There is no postMessage event fired after finish validating form in preview mode so I made it open in new tab.