### PR TITLE
OC Cosmetic

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableFactory.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableFactory.java
@@ -107,9 +107,9 @@ public class ListNotesTableFactory extends AbstractTableFactory {
     protected void configureColumns(TableFacade tableFacade, Locale locale) {
 
         tableFacade.setColumnProperties("studySubject.label",
-                "discrepancyNoteBean.createdDate",
                 "discrepancyNoteBean.resolutionStatus",
                 "siteId",
+                "discrepancyNoteBean.createdDate",
                 "discrepancyNoteBean.updatedDate",
                 "age",
                 "days",
@@ -117,12 +117,12 @@ public class ListNotesTableFactory extends AbstractTableFactory {
                 "eventStartDate",
                 "crfName",
                 "crfStatus",
-                "discrepancyNoteBean.detailedNotes",
-                "numberOfNotes",
-                "discrepancyNoteBean.user",
                 "entityName",
                 "entityValue",
                 "discrepancyNoteBean.entityType",
+                "discrepancyNoteBean.detailedNotes",
+                "numberOfNotes",
+                "discrepancyNoteBean.user",
                 "actions");
 
         Row row = tableFacade.getTable().getRow();

--- a/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableToolbar.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableToolbar.java
@@ -222,7 +222,7 @@ public class ListNotesTableToolbar extends DefaultToolbar {
         @Override
         public String enabled() {
             HtmlBuilder html = new HtmlBuilder();
-            html.a().href("#");
+            html.a().href("javascript:void(0)");
             html.onclick("javascript:openPopup()");
             html.quote();
             html.append(getAction());

--- a/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableToolbar.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableToolbar.java
@@ -136,7 +136,7 @@ public class ListNotesTableToolbar extends DefaultToolbar {
          *      java.util.Locale)
          */
         String getIndexes() {
-            String result = "1, 4, 8, 10, 12, 16";
+            String result = "3, 4, 8, 10, 13, 15";
             return result;
         }
 


### PR DESCRIPTION
Queries Table - Change order of columns when Show More is clicked - Move Date Created to between Site ID and Date Updated. Move Item Name, Item Value, and Item Type to between CRF Status and Detailed Notes.
![screenshot from 2017-11-01 15-58-46](https://user-images.githubusercontent.com/13865076/32265359-a8583aae-bf1d-11e7-8dda-5758ce4d243c.png)

Queries Table - Change order of columns in Brief (Hide) views - Move Item Name and  Item Value to between CRF and Detailed Notes.
![screenshot from 2017-11-01 15-59-19](https://user-images.githubusercontent.com/13865076/32265371-b2eb2c06-bf1d-11e7-925d-06f8349a599d.png)
