### PR TITLE
OC Cosmetic

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/service/managestudy/ViewNotesFilterCriteria.java
+++ b/core/src/main/java/org/akaza/openclinica/service/managestudy/ViewNotesFilterCriteria.java
@@ -56,6 +56,7 @@ public class ViewNotesFilterCriteria {
         FILTER_BY_TABLE_COLUMN.put("discrepancyNoteBean.description", "description");
         FILTER_BY_TABLE_COLUMN.put("discrepancyNoteBean.detailedNotes", "detailed_notes");
         FILTER_BY_TABLE_COLUMN.put("discrepancyNoteBean.user", "user");
+        FILTER_BY_TABLE_COLUMN.put("discrepancyNoteBean.discrepancyNoteTypeId", "discrepancy_note_type_id");
     }
 
     private final Map<String, Object> filters = new HashMap<String, Object>();

--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/ViewSectionDataEntryServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/ViewSectionDataEntryServlet.java
@@ -130,7 +130,11 @@ public class ViewSectionDataEntryServlet extends DataEntryServlet {
         boolean isSubmitted = false;
         EventDefinitionCRFBean edcb = (EventDefinitionCRFBean) request.getAttribute(EVENT_DEF_CRF_BEAN);
         if (!fp.getString("exitTo").equals("")) {
-            request.setAttribute("exitTo", fp.getString("exitTo"));
+            String exitTo = fp.getString("exitTo");
+            if (exitTo.indexOf("viewAllSubjectSDVtmp") > -1) {
+                exitTo += "&studyId=" + currentStudy.getId();
+            }
+            request.setAttribute("exitTo", exitTo);
         }
         int crfVersionId = fp.getInt("crfVersionId", true);
         int sectionId = fp.getInt("sectionId");

--- a/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableFactory.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableFactory.java
@@ -366,7 +366,7 @@ public class ListNotesTableFactory extends AbstractTableFactory {
             ResolutionStatus status = (ResolutionStatus) ((HashMap<Object, Object>) item).get("discrepancyNoteBean.resolutionStatus");
 
             if (status != null) {
-                value = "<span class=\"" + status.getIconFilePath() + "\" border=\"0\" align=\"left\"> &nbsp;&nbsp;" + status.getName();
+                value = "<span class=\"" + status.getIconFilePath() + "\" border=\"0\" align=\"left\"> <text>" + status.getName() + "</text>";
             }
             return value;
         }

--- a/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableFactory.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableFactory.java
@@ -185,6 +185,9 @@ public class ListNotesTableFactory extends AbstractTableFactory {
         int parentStudyId = 0;
 
         Limit limit = tableFacade.getLimit();
+        // Show only QUERY note type
+        limit.getFilterSet().addFilter(new Filter("discrepancyNoteBean.discrepancyNoteTypeId","Query"));
+
         if (!limit.isComplete()) {
             parentStudyId = currentStudy.getId();
 

--- a/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableToolbar.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableToolbar.java
@@ -136,7 +136,7 @@ public class ListNotesTableToolbar extends DefaultToolbar {
          *      java.util.Locale)
          */
         String getIndexes() {
-            String result = "4, 5, 9, 11, 14, 16";
+            String result = "3, 4, 8, 10, 13, 15";
             return result;
         }
 

--- a/web/src/main/java/org/akaza/openclinica/web/table/sdv/SDVUtil.java
+++ b/web/src/main/java/org/akaza/openclinica/web/table/sdv/SDVUtil.java
@@ -997,10 +997,10 @@ public class SDVUtil {
     private String getCRFStatusIconPath(int statusId, HttpServletRequest request, int studySubjectId, int eventDefinitionCRFId, int crfVersionId) {
 
         HtmlBuilder html = new HtmlBuilder();
-        html.a().onclick(
-                "openDocWindow('" + request.getContextPath() + "/ViewSectionDataEntry?eventDefinitionCRFId=&ecId=" + eventDefinitionCRFId
-                    + "&tabId=1&studySubjectId=" + studySubjectId + "');");
-        html.href("#").close();
+//        html.a().onclick(
+//                "openDocWindow('" + request.getContextPath() + "/ViewSectionDataEntry?eventDefinitionCRFId=&ecId=" + eventDefinitionCRFId
+//                    + "&tabId=1&studySubjectId=" + studySubjectId + "');");
+//        html.href('#').close();
 
         StringBuilder builderHref = new StringBuilder("<a href='javascript:void(0)' onclick=\"");
         //ViewSectionDataEntry?eventDefinitionCRFId=127&crfVersionId=682&tabId=1&studySubjectId=203
@@ -1013,7 +1013,8 @@ public class SDVUtil {
         String imgName = "";
         StringBuilder input = new StringBuilder("<input type=\"hidden\" statusId=\"");
         input.append(statusId).append("\" />");
-        builder.append("<center><span title=\"View CRF\" alt=\"View CRF\" class='" + CRF_STATUS_ICONS.get(statusId) + "' border='0'></center>");
+        builder.append("<center><a title=\"View CRF\" alt=\"View CRF\" class='" + CRF_STATUS_ICONS.get(statusId) + "' border='0' href='" + request.getContextPath() + "/ViewSectionDataEntry?eventDefinitionCRFId=&ecId=" + eventDefinitionCRFId
+                + "&tabId=1&studySubjectId=" + studySubjectId + "&exitTo=pages/viewAllSubjectSDVtmp?sdv_restore=true' ></a></center>");
         //"<input type=\"hidden\" statusId=\"1\" />"
         builder.append("</a>");
         builder.append(" ");

--- a/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
@@ -162,7 +162,7 @@
                             <table border="0" cellpadding="0" cellspacing="0" width="100%">
                                 <tr>
                                     <td>
-                                      <form METHOD="GET" action="${urlPrefix}ListStudySubjects" onSubmit=" if (document.forms[0]['findSubjects_f_studySubject.label'].value == '<fmt:message key="study_subject_ID" bundle="${resword}"/>') { document.forms[0]['findSubjects_f_studySubject.label'].value=''}">
+                                      <form METHOD="GET" id="searchByStudySubjectId" action="${urlPrefix}ListStudySubjects" onSubmit=" if (document.forms[0]['findSubjects_f_studySubject.label'].value == '<fmt:message key="study_subject_ID" bundle="${resword}"/>') { document.forms[0]['findSubjects_f_studySubject.label'].value=''}">
                                                                     <!--<a href="javascript:reportBug()">Report Issue</a>|-->
                                             <input type="text" name="findSubjects_f_studySubject.label" onblur="if (this.value == '') this.value = '<fmt:message key="study_subject_ID" bundle="${resword}"/>'" onfocus="if (this.value == '<fmt:message key="study_subject_ID" bundle="${resword}"/>') this.value = ''" value='<fmt:message key="study_subject_ID" bundle="${resword}"/>' class="navSearch"/>
                                             <input type="hidden" name="navBar" value="yes"/>

--- a/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
@@ -7,9 +7,6 @@
 <fmt:setBundle basename="org.akaza.openclinica.i18n.words" var="resword"/>
 <fmt:setBundle basename="org.akaza.openclinica.i18n.format" var="resformat"/>
 
-<script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jquery.min.js"></script>
-<script type="text/javascript" language="JavaScript" src="includes/jmesa/jquery.blockUI.js"></script>
-
 <script language="JavaScript">
 
         // Walkme snippet
@@ -78,12 +75,21 @@
 <c:set var="urlPrefix" value=""/>
 <c:set var="requestFromSpringController" value="${param.isSpringController}" />
 <c:set var="requestFromSpringControllerCCV" value="${param.isSpringControllerCCV}" />
-<c:if test="${requestFromSpringController == 'true' || requestFromSpringControllerCCV == 'true'}">
-      <c:set var="urlPrefix" value="${pageContext.request.contextPath}/"/>
-</c:if>
+<c:choose>
+    <c:when test="${requestFromSpringController == 'true' || requestFromSpringControllerCCV == 'true'}">
+        <c:set var="urlPrefix" value="${pageContext.request.contextPath}/"/>
+        <script type="text/JavaScript" language="JavaScript" src="../includes/jmesa/jquery.min.js"></script>
+        <script type="text/javascript" language="JavaScript" src="../includes/jmesa/jquery.blockUI.js"></script>
+        <link rel="stylesheet" href="../includes/css/icomoon-style.css">
+    </c:when>
+    <c:otherwise>
+        <script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jquery.min.js"></script>
+        <script type="text/javascript" language="JavaScript" src="includes/jmesa/jquery.blockUI.js"></script>
+        <link rel="stylesheet" href="includes/css/icomoon-style.css">
+    </c:otherwise>
+</c:choose>
 
 <!-- Main Navigation -->
-    <link rel="stylesheet" href="includes/css/icomoon-style.css">
      <div class="oc_nav">
         <div class="nav-top-bar">
         <!-- Logo -->

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudyEvent.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudyEvent.jsp
@@ -9,6 +9,8 @@
 <jsp:useBean scope="request" id="studyEvent" class="org.akaza.openclinica.bean.managestudy.StudyEventBean" />
 <jsp:useBean scope="request" id="studySubject" class="org.akaza.openclinica.bean.managestudy.StudySubjectBean" />
 
+<link rel="stylesheet" href="includes/font-awesome-4.7.0/css/font-awesome.css">
+
 <c:choose>
  <c:when test="${isAdminServlet == 'admin' && userBean.sysAdmin && module=='admin'}">
    <c:import url="../include/admin-header.jsp"/>

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/viewNotesPrint.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/viewNotesPrint.jsp
@@ -43,6 +43,7 @@
 	<td class="table_header_row"><fmt:message key="CRF_status" bundle="${resword}"/></td>
 	<td class="table_header_row"><fmt:message key="entity_name" bundle="${resword}"/></td>
 	<td class="table_header_row"><fmt:message key="entity_value" bundle="${resword}"/></td>
+	<td class="table_header_row"><fmt:message key="entity_type" bundle="${resword}"/></td>
 	<td class="table_header_row"><fmt:message key="detailed_notes" bundle="${resword}"/></td>
 	<td class="table_header_row"><fmt:message key="of_notes" bundle="${resword}"/></td>
 	<td class="table_header_row"><fmt:message key="assigned_user" bundle="${resword}"/></td>
@@ -73,6 +74,7 @@
 	    <c:out value="${note.entityName}"/>&nbsp;	 
 	</td>
 	<td class="table_cell"><c:out value="${note.entityValue}" />&nbsp;</td>
+	<td class="table_cell"><c:out value="${note.entityType}" />&nbsp;</td>
     <td class="table_cell" width="400">		
 	 <c:out value="${note.detailedNotes}" />&nbsp; 
 	</td>

--- a/web/src/main/webapp/includes/styles.css
+++ b/web/src/main/webapp/includes/styles.css
@@ -584,7 +584,7 @@ form[action="UpdateSubStudy"] .textbox_center td.table_cell, form[action="Update
 .jmesa .fa, .jmesa .icon {
   font-size: .9em; }
 
-.jmesa td {
+.jmesa td, .jmesa td text {
   font-size: .85rem; }
 
 .jmesa .table {
@@ -617,7 +617,7 @@ form[action="UpdateSubStudy"] .textbox_center td.table_cell, form[action="Update
 .jmesa table#findSubjects .odd > td, .jmesa table#findSubjects .even > td, .jmesa table#findSubjects .highlight > td, .jmesa table#findSubjects td table td {
   vertical-align: middle; }
 
-.jmesa table:not(#studyAuditLogs) .odd td, .jmesa table:not(#studyAuditLogs) .even td, .jmesa table:not(#studyAuditLogs) .highlight td {
+.jmesa table:not(#studyAuditLogs) .odd td, .jmesa table:not(#studyAuditLogs) .even td, .jmesa table:not(#studyAuditLogs) .highlight td, .jmesa table#listNotes td text {
   border: none;
   font-family: 'Open Sans', arial, helvetica, sans-serif;
   font-weight: 400;

--- a/web/src/main/webapp/includes/styles.css
+++ b/web/src/main/webapp/includes/styles.css
@@ -867,3 +867,7 @@ div#subjectSDV table#sdv {
 body.query-page .aka_revised_content{
   max-width: 100%;
 }
+
+form#searchByStudySubjectId {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
- Queries Table - Click Print icon. The columns included and their order should match the columns and order on the screen when Show More is clicked. (Item Type column is still missing from the Print view)
![screenshot from 2017-11-07 18-24-15](https://user-images.githubusercontent.com/13865076/32494380-6ed2cb76-c3fc-11e7-90e2-4fef51660ef4.png)

- Queries Table - Note Type column - We don’t need this column after all. Sorry for the confusion. Please remove it from the onscreen table and print view. However, we need to filter the data coming into the table so that only note type = “Query” is ever included. Even if the user clears filters or adds other filters, only note type = “Query” should be included in any of the views.

- The font for the values in the Resolution Status column uses small text. It doesn’t match the other columns.
![screenshot from 2017-11-07 20-38-50](https://user-images.githubusercontent.com/13865076/32494431-9c039c88-c3fc-11e7-9334-a641f8204d6e.png)
