### PR TITLE
Edit Manual Testing/Bug Fixing - Misc Cosmetic Issues (012/11/17 progress)

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/control/admin/ListCRFServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/admin/ListCRFServlet.java
@@ -164,16 +164,6 @@ public class ListCRFServlet extends SecureController {
         panel.setExtractData(false);
         panel.setCreateDataset(false);
 
-        if (crfs.size() > 0) {
-            setToPanel("CRFs", new Integer(crfs.size()).toString());
-        }
-
-        setToPanel(resword.getString("create_CRF"), respage.getString("br_create_new_CRF_entering"));
-
-        setToPanel(resword.getString("create_CRF_version"), respage.getString("br_create_new_CRF_uploading"));
-        setToPanel(resword.getString("revise_CRF_version"), respage.getString("br_if_you_owner_CRF_version"));
-        setToPanel(resword.getString("CRF_spreadsheet_template"), respage.getString("br_download_blank_CRF_spreadsheet_from"));
-        setToPanel(resword.getString("example_CRF_br_spreadsheets"), respage.getString("br_download_example_CRF_instructions_from"));
         forwardPage(Page.CRF_LIST);
     }
 

--- a/web/src/main/java/org/akaza/openclinica/control/admin/ViewCRFServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/admin/ViewCRFServlet.java
@@ -82,12 +82,6 @@ public class ViewCRFServlet extends SecureController {
         panel.setExtractData(false);
         panel.setCreateDataset(false);
 
-        setToPanel(resword.getString("create_CRF"), respage.getString("br_create_new_CRF_entering"));
-        setToPanel(resword.getString("create_CRF_version"), respage.getString("br_create_new_CRF_uploading"));
-        setToPanel(resword.getString("revise_CRF_version"), respage.getString("br_if_you_owner_CRF_version"));
-        setToPanel(resword.getString("CRF_spreadsheet_template"), respage.getString("br_download_blank_CRF_spreadsheet_from"));
-        setToPanel(resword.getString("example_CRF_br_spreadsheets"), respage.getString("br_download_example_CRF_instructions_from"));
-
         FormProcessor fp = new FormProcessor(request);
 
         // checks which module the requests are from, manage or admin

--- a/web/src/main/resources/org/akaza/openclinica/i18n/notes.properties
+++ b/web/src/main/resources/org/akaza/openclinica/i18n/notes.properties
@@ -1,7 +1,7 @@
 
 As_a_Technical_Administrator_you_have_privileges_to = As a Technical Administrator you have privileges to administer everything that a Business Administrator can--all subjects, users, CRFs and studies/sites created across the system. Technical Administrators have 'super-user' privileges over other user accounts and may not be disabled or modified by Business Administrators.
 
-CRF_library_shows_all_CRFs = The Case Report Form (CRF) Library shows all CRFs available for use in studies. CRFs may have one or more versions, each with its own version name. You may add any existing CRF to a Study Event Definition in your study. You may also create a new OpenClinica CRF or CRF version using the Excel template provided below and uploading it to the system.
+CRF_library_shows_all_CRFs = The Case Report Form (CRF) Library shows all CRFs available for use in this study. CRFs may have one or more versions, each with its own version name.
 
 CRF_name_case_sensitive = The CRF Name is case sensitive. It must match the name of the CRF_Name field in the CRF worksheet of the Excel file.
 


### PR DESCRIPTION
CRF Details Page (Tasks > CRFs > click the View link for a CRF) - Remove all of the text from the left side Info (Other Info) section.
before:
![before- crf details page tasks crfs click the view link for a crf - remove all of the text from the left side info other info section](https://user-images.githubusercontent.com/16472454/32698097-602da91e-c7d1-11e7-85a4-8ef9d8b47ba0.png)
after:
![after-crf details page tasks crfs click the view link for a crf - remove all of the text from the left side info other info section](https://user-images.githubusercontent.com/16472454/32698106-9fbdc8f2-c7d1-11e7-92e8-3d09e305df8b.png)


Manage CRFs Page (Tasks > CRFs) - Remove all of the text from the left side Info (Other Info) section.
before:
![remove all of the text from the left side info other info section](https://user-images.githubusercontent.com/16472454/32698101-802a9ec0-c7d1-11e7-921b-3766ca2ed98f.png)
after:
![after-commit 39cc2687f4a58fd95f6e2ec5225a4e6d90022175](https://user-images.githubusercontent.com/16472454/32698098-6beda038-c7d1-11e7-9add-00c46642e728.png)

Manage CRFs Page (Tasks > CRFs) - Change the text in the left side Instructions section to: “The Case Report Form (CRF) Library shows all CRFs available for use in this study. CRFs may have one or more versions, each with its own version name.”
before:
![before-manage crfs page tasks crfs - change the text in the left side instructions section to the case report form crf library shows all crfs available for use in this study crfs may have one or more versions each with its own version name1](https://user-images.githubusercontent.com/16472454/32698110-b1ccd286-c7d1-11e7-829d-78c7a7e8b14f.png)
after:
![after- the case report form crf library shows all crfs available for use in this study crfs may have one or more versions each with its own version name](https://user-images.githubusercontent.com/16472454/32698113-bee6c526-c7d1-11e7-87b3-2beb05bb6b02.png)




