### PR TITLE
Edit Manual Testing/Bug Fixing - Misc Cosmetic Issues (17/11/17 progress)

### DIFF
--- a/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
@@ -150,6 +150,9 @@
                     <c:if test="${study.status.frozen}">
                         <span class="status-tag status-${fn:toLowerCase(study.envType)}"><fmt:message key="test_environment" bundle="${resword}"/> | <fmt:message key="frozen" bundle="${resword}"/></span>
                     </c:if>
+                    <c:if test="${study.status.available}">
+                        <span class="status-tag status-${fn:toLowerCase(study.envType)}"><fmt:message key="test_environment" bundle="${resword}"/></span>
+                    </c:if>
                 </c:if>&nbsp;&nbsp;|&nbsp;&nbsp;
                 <a href="${urlPrefix}ChangeStudy"><fmt:message key="change" bundle="${resword}"/></a>
 

--- a/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
@@ -128,7 +128,21 @@
                         <b><a href="${urlPrefix}ViewStudy?id=${study.id}&viewFull=yes" title="<c:out value='${study.name}'/>" alt="<c:out value='${study.name}'/>"><c:out value="${study.abbreviatedName}" /></a></b>
                     </c:otherwise>
                 </c:choose>
-                (<c:out value="${study.abbreviatedIdentifier}" />)&nbsp;&nbsp;<c:if test="${study.envType == 'TEST'}"><span class="status-tag status-${fn:toLowerCase(study.envType)}"><fmt:message key="test_environment" bundle="${resword}"/></span></c:if>&nbsp;&nbsp;|&nbsp;&nbsp;
+                (<c:out value="${study.abbreviatedIdentifier}" />)&nbsp;&nbsp;
+                <c:if test="${study.envType == 'PROD'}">
+                    <c:if test="${study.status.pending}">
+                        <span class="status-tag status-${fn:toLowerCase(study.envType)}"><fmt:message key="design" bundle="${resword}"/></span>
+                    </c:if>
+                    <c:if test="${study.status.locked}">
+                        <span class="status-tag status-${fn:toLowerCase(study.envType)}"><fmt:message key="locked" bundle="${resword}"/></span>
+                    </c:if>
+                    <c:if test="${study.status.frozen}">
+                        <span class="status-tag status-${fn:toLowerCase(study.envType)}"><fmt:message key="frozen" bundle="${resword}"/></span>
+                    </c:if>
+                </c:if>
+                <c:if test="${study.envType == 'TEST'}">
+                    <span class="status-tag status-${fn:toLowerCase(study.envType)}"><fmt:message key="test_environment" bundle="${resword}"/></span>
+                </c:if>&nbsp;&nbsp;|&nbsp;&nbsp;
                 <a href="${urlPrefix}ChangeStudy"><fmt:message key="change" bundle="${resword}"/></a>
 
             </div>

--- a/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
@@ -141,7 +141,15 @@
                     </c:if>
                 </c:if>
                 <c:if test="${study.envType == 'TEST'}">
-                    <span class="status-tag status-${fn:toLowerCase(study.envType)}"><fmt:message key="test_environment" bundle="${resword}"/></span>
+                    <c:if test="${study.status.pending}">
+                        <span class="status-tag status-${fn:toLowerCase(study.envType)}"><fmt:message key="test_environment" bundle="${resword}"/> | <fmt:message key="design" bundle="${resword}"/></span>
+                    </c:if>
+                    <c:if test="${study.status.locked}">
+                        <span class="status-tag status-${fn:toLowerCase(study.envType)}"><fmt:message key="test_environment" bundle="${resword}"/> | <fmt:message key="locked" bundle="${resword}"/></span>
+                    </c:if>
+                    <c:if test="${study.status.frozen}">
+                        <span class="status-tag status-${fn:toLowerCase(study.envType)}"><fmt:message key="test_environment" bundle="${resword}"/> | <fmt:message key="frozen" bundle="${resword}"/></span>
+                    </c:if>
                 </c:if>&nbsp;&nbsp;|&nbsp;&nbsp;
                 <a href="${urlPrefix}ChangeStudy"><fmt:message key="change" bundle="${resword}"/></a>
 


### PR DESCRIPTION
If the current study/site status is “Locked” (for locked), “Frozen” (for frozen), or “Design” (for design/pending), show the status in the title bar in an orange box. 
If it is a Production study, show this between the study name and “ | Change” link.
Example:    PAB 19 (PAB19)  Locked  |   Change
before:
![before prod](https://user-images.githubusercontent.com/16472454/32926328-4214f2b0-cb79-11e7-8076-2a2d854212af.png)
after:
![after prod](https://user-images.githubusercontent.com/16472454/32926346-544d6516-cb79-11e7-9e15-f83a8265b32b.png)

If it is a Test study, show this between “Test Environment | “ and “ | Change” link.
Example:    PAB 19 (PAB19)  Test Environment  |  Frozen  |   Change
before:
![test environment before](https://user-images.githubusercontent.com/16472454/32926374-7988dec8-cb79-11e7-82fa-d3e48cb04e90.png)
after:
![test environemnet before](https://user-images.githubusercontent.com/16472454/32926380-81c7191a-cb79-11e7-9e79-d2a5f9c6e959.png)

If status is Available, do not display the status in the title bar.
result:
![available prod](https://user-images.githubusercontent.com/16472454/32926399-97631a6c-cb79-11e7-9a51-4ebb9e5d1edc.png)
![test available](https://user-images.githubusercontent.com/16472454/32926400-97a5a576-cb79-11e7-89da-37b2d71f299a.png)



