### PR TITLE
OC-Cosmetic-Master

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/control/submit/AddNewSubjectServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/AddNewSubjectServlet.java
@@ -276,7 +276,7 @@ public class AddNewSubjectServlet extends SecureController {
             v.addValidation(INPUT_ENROLLMENT_DATE, Validator.DATE_IN_PAST);
 
             boolean locationError = false;
-            if (fp.getBoolean("addWithEvent")) {
+            if (fp.getBoolean("addWithEvent") && fp.getInt("studyEventDefinition") > 0) {
                 v.addValidation(INPUT_EVENT_START_DATE, Validator.IS_A_DATE);
                 v.alwaysExecuteLastValidation(INPUT_EVENT_START_DATE);
                 if(currentStudy.getStudyParameterConfig().getEventLocationRequired().equalsIgnoreCase("required")){

--- a/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/navBar.jsp
@@ -926,7 +926,8 @@
 
                             <tr valign="top">
                                 <td class="formlabel" align="left">
-                                    <span class="addNewStudyLayout"><fmt:message key="start_date" bundle="${resword}"/></span>&nbsp;<small class="required">*
+                                    <span class="addNewStudyLayout"><fmt:message key="start_date" bundle="${resword}"/>
+                                    <c:if test="${studyEventDefinition > 0}">&nbsp;<small class="required">*</c:if>
                                 </small>
                                 </td>
                                 <td valign="top">

--- a/web/src/main/webapp/WEB-INF/jsp/submit/addNewSubjectExpressNew.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/addNewSubjectExpressNew.jsp
@@ -351,7 +351,8 @@
 
                 <tr valign="top">
                     <td class="formlabel" align="left">
-                        <span class="addNewStudyLayout"><fmt:message key="start_date" bundle="${resword}"/></span>&nbsp;<small class="required">*</small>
+                        <span class="addNewStudyLayout"><fmt:message key="start_date" bundle="${resword}"/></span>
+                        <c:if test="${studyEventDefinition > 0}">&nbsp;<small class="required">*</c:if>
                     </td>
                     <td valign="top">
                         <table border="0" cellpadding="0" cellspacing="0" class="full-width">


### PR DESCRIPTION
 OC-8549 Add Subject Start Date should be conditionally required

As a data entry user, I only want to enter event date when adding a subject when I am selecting an event for the subject.
AC1: Study Event is not required in the Add Subject window.
![screenshot from 2017-11-22 10-13-01](https://user-images.githubusercontent.com/13865076/33107126-b61d85be-cf70-11e7-8854-ae959155549a.png)

AC2: If an event is not select for Study Event, Start Date is not required.
![screenshot from 2017-11-22 10-13-36](https://user-images.githubusercontent.com/13865076/33107139-ca8f3880-cf70-11e7-87ee-ff7079c73d9b.png)

AC3: If an event is selected for Study Event, Start Date is required.
![screenshot from 2017-11-22 10-14-23](https://user-images.githubusercontent.com/13865076/33107141-cc9e645c-cf70-11e7-9dd7-cfd67bac5aac.png)
