### PR TITLE
Oc 8565 Show count of queries by form and status on Signature Page

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/dao/managestudy/DiscrepancyNoteDAO.java
+++ b/core/src/main/java/org/akaza/openclinica/dao/managestudy/DiscrepancyNoteDAO.java
@@ -1186,14 +1186,14 @@ public class DiscrepancyNoteDAO extends AuditableEntityDAO {
 
     }
 
-    public ArrayList<DiscrepancyNoteBean> findAllChildrenItemDataDNotesFromEventCRF(EventCRFBean eventCRFBean) {
+    public ArrayList<DiscrepancyNoteBean> findParentItemDataDNotesFromEventCRF(EventCRFBean eventCRFBean) {
 
         this.setTypesExpected();
         ArrayList dNotelist = new ArrayList();
 
         HashMap variables = new HashMap();
         variables.put(Integer.valueOf(1), Integer.valueOf(eventCRFBean.getId()));
-        dNotelist = this.select(digester.getQuery("findAllChildrenItemDataDNotesFromEventCRF"), variables);
+        dNotelist = this.select(digester.getQuery("findParentItemDataDNotesFromEventCRF"), variables);
 
         ArrayList<DiscrepancyNoteBean> returnedNotelist = new ArrayList<DiscrepancyNoteBean>();
         Iterator it = dNotelist.iterator();

--- a/core/src/main/java/org/akaza/openclinica/service/DiscrepancyNoteUtil.java
+++ b/core/src/main/java/org/akaza/openclinica/service/DiscrepancyNoteUtil.java
@@ -367,7 +367,7 @@ public class DiscrepancyNoteUtil {
         return newBeans;
     }
 
-    public void injectAllChildrenDiscNotesIntoDisplayStudyEvents(List<DisplayStudyEventBean> displayStudyBeans, Set<Integer> resolutionStatusIds,
+    public void injectParentDiscNotesIntoDisplayStudyEvents(List<DisplayStudyEventBean> displayStudyBeans, Set<Integer> resolutionStatusIds,
             DataSource dataSource, int discNoteType) {
 
         if (displayStudyBeans == null) {
@@ -393,7 +393,7 @@ public class DiscrepancyNoteUtil {
 
             for (EventCRFBean eventCrfBean : eventCRFBeans) {
                 // Find ItemData type notes associated with an event crf
-                foundDiscNotes = discrepancyNoteDAO.findAllChildrenItemDataDNotesFromEventCRF(eventCrfBean);
+                foundDiscNotes = discrepancyNoteDAO.findParentItemDataDNotesFromEventCRF(eventCrfBean);
 
                 // filter for any specified disc note type
                 if (!foundDiscNotes.isEmpty() && hasDiscNoteType) {

--- a/core/src/main/resources/properties/discrepancy_note_dao.xml
+++ b/core/src/main/resources/properties/discrepancy_note_dao.xml
@@ -1020,18 +1020,6 @@ union
         </sql>
     </query>
 
-     <query>
-        <name>findAllChildrenItemDataDNotesFromEventCRF</name>
-        <sql>
-            SELECT dn.* FROM discrepancy_note dn, dn_item_data_map dn_idmap,
-            item_data idata, event_crf eventcrf WHERE eventcrf.event_crf_id = ?
-            AND
-            idata.event_crf_id = eventcrf.event_crf_id
-            AND idata.item_data_id =dn_idmap.item_data_id
-            AND dn_idmap.discrepancy_note_id=dn.discrepancy_note_id
-            AND ((dn.parent_dn_id IS NOT NULL) or (dn.parent_dn_id != 0))
-        </sql>
-    </query>
 
     <query>
         <name>findEventCRFDNotesFromEventCRF</name>

--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/SignStudySubjectServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/SignStudySubjectServlet.java
@@ -273,7 +273,7 @@ public class SignStudySubjectServlet extends SecureController {
                 }
 
                 DiscrepancyNoteUtil discNoteUtil = new DiscrepancyNoteUtil();
-                discNoteUtil.injectAllChildrenDiscNotesIntoDisplayStudyEvents(displayEvents, new HashSet(), sm.getDataSource(), 0);
+                discNoteUtil.injectParentDiscNotesIntoDisplayStudyEvents(displayEvents, new HashSet(), sm.getDataSource(), 0);
 
                 Map discNoteByEventCRFid = discNoteUtil.createDiscNoteMapByEventCRF(displayEvents);
                 String originationUrl = "SignStudySubject?id=" + studySub.getId();
@@ -346,7 +346,7 @@ public class SignStudySubjectServlet extends SecureController {
         DiscrepancyNoteUtil discNoteUtil = new DiscrepancyNoteUtil();
         // Don't filter for now; disc note beans are returned with eventCRFId
         // set
-        discNoteUtil.injectAllChildrenDiscNotesIntoDisplayStudyEvents(displayEvents, new HashSet(), sm.getDataSource(), 0);
+        discNoteUtil.injectParentDiscNotesIntoDisplayStudyEvents(displayEvents, new HashSet(), sm.getDataSource(), 0);
         // All the displaystudyevents for one subject
 
         // Set up a Map for the JSP view, mapping the eventCRFId to another Map:

--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/UpdateStudyEventServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/UpdateStudyEventServlet.java
@@ -466,7 +466,7 @@ public class UpdateStudyEventServlet extends SecureController {
                 displayEvents.add(displayEvBean);
                 // Don't filter for res status or disc note type; disc note
                 // beans are returned with eventCRFId set
-                discNoteUtil.injectAllChildrenDiscNotesIntoDisplayStudyEvents(displayEvents, new HashSet(), sm.getDataSource(), 0);
+                discNoteUtil.injectParentDiscNotesIntoDisplayStudyEvents(displayEvents, new HashSet(), sm.getDataSource(), 0);
                 Map discNoteByEventCRFid = discNoteUtil.createDiscNoteMapByEventCRF(displayEvents);
                 request.setAttribute("discNoteByEventCRFid", discNoteByEventCRFid);
                 session.setAttribute("signatureURL", request.getRequestURL());
@@ -609,7 +609,7 @@ public class UpdateStudyEventServlet extends SecureController {
                 displayEvBean.setDisplayEventCRFs(displayEventCRFs);
                 displayEvBean.setStudyEvent(studyEvent);
                 displayEvents.add(displayEvBean);
-                discNoteUtil.injectAllChildrenDiscNotesIntoDisplayStudyEvents(displayEvents, new HashSet(), sm.getDataSource(), 0);
+                discNoteUtil.injectParentDiscNotesIntoDisplayStudyEvents(displayEvents, new HashSet(), sm.getDataSource(), 0);
                 Map discNoteByEventCRFid = discNoteUtil.createDiscNoteMapByEventCRF(displayEvents);
                 request.setAttribute("discNoteByEventCRFid", discNoteByEventCRFid);
                 request.setAttribute("studySubject", ssb);

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/signStudySubject.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/signStudySubject.jsp
@@ -462,6 +462,12 @@
             <c:otherwise>
             <c:set var="getQuery" value="action=ide_s&eventDefinitionCRFId=${dedc.edc.id}&studyEventId=${studyEvent.id}&subjectId=${studySubject.subjectId}&eventCRFId=${dedc.eventCRF.id}" />
                 <tr valign="top">
+                            <c:set var="repeat" value="${dse.studyEvent.studyEventDefinition.name}(${dse.studyEvent.sampleOrdinal})" />
+            <c:set var="non_repeat" value="${dse.studyEvent.studyEventDefinition.name}" />            
+            
+                <td class="table_cell"><c:out value="${ dse.studyEvent.studyEventDefinition.repeating ? repeat :non_repeat }" />&nbsp;</td>
+                <td class="table_cell"><fmt:formatDate value="${dse.studyEvent.dateStarted}" pattern="${dteFormat}"/>&nbsp;</td>              
+                
                     <td class="table_cell_left"><c:out value="${dedc.edc.crf.name}" /></td>
                   <td class="table_cell">
 
@@ -568,22 +574,18 @@
                     </c:when>
 
                     <c:when test="${studySubject.status.name != 'removed'&& studySubject.status.name != 'auto-removed'}">
-                    <td class="table_cell">
-                            <a href="EnketoFormServlet?formLayoutId=<c:out value="${dedc.edc.defaultVersionId}"/>&studyEventId=<c:out value="${studyEvent.id}"/>&eventCrfId=<c:out value="${dedc.eventCRF.id}"/>&originatingPage=<c:out value="${originatingPage}"/>&mode=<c:out value="edit"/>"
+                            <a href="EnketoFormServlet?formLayoutId=<c:out value="${dedc.edc.defaultVersionId}"/>&studyEventId=<c:out value="${dse.studyEvent.id}"/>&eventCrfId=<c:out value="${dedc.eventCRF.id}"/>&originatingPage=<c:out value="${originatingPage}"/>&mode=<c:out value="edit"/>"
                             onMouseDown="javascript:setImage('bt_EnterData<c:out value="${rowCount}"/>','images/bt_EnterData_d.gif');"
                             onMouseUp="javascript:setImage('bt_EnterData<c:out value="${rowCount}"/>','images/bt_EnterData.gif');"
                             ><span name="bt_EnterData<c:out value="${rowCount}"/>" class="icon icon-pencil-squared" border="0" alt="<fmt:message key="enter_data" bundle="${resword}"/>" title="<fmt:message key="enter_data" bundle="${resword}"/>" align="left" hspace="2"></a>&nbsp;
-                    </td>
                     </c:when>
 
                     <c:otherwise></c:otherwise>
                     </c:choose>
-                    <td class="table_cell">
-                                   <a href="EnketoFormServlet?formLayoutId=<c:out value="${dedc.edc.defaultVersionId}"/>&studyEventId=<c:out value="${studyEvent.id}"/>&eventCrfId=<c:out value="${dedc.eventCRF.id}"/>&originatingPage=<c:out value="${originatingPage}"/>&mode=<c:out value="view"/>"
+                                   <a href="EnketoFormServlet?formLayoutId=<c:out value="${dedc.edc.defaultVersionId}"/>&studyEventId=<c:out value="${dse.studyEvent.id}"/>&eventCrfId=<c:out value="${dedc.eventCRF.id}"/>&originatingPage=<c:out value="${originatingPage}"/>&mode=<c:out value="view"/>"
                       onMouseDown="javascript:setImage('bt_View1','images/bt_View_d.gif');"
                       onMouseUp="javascript:setImage('bt_View1','images/bt_View.gif');"><span
                       name="bt_View1" align="left" class="icon icon-search" border="0" alt="<fmt:message key="view_default" bundle="${resword}"/>" title="<fmt:message key="view_default" bundle="${resword}"/>" hspace="2"></a>&nbsp;
-                  </td>
                   </tr>
                     </table>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudyEventSigned.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudyEventSigned.jsp
@@ -394,22 +394,18 @@
                     </c:when>
 
                     <c:when test="${studySubject.status.name != 'removed'&& studySubject.status.name != 'auto-removed'}">
-                    <td class="table_cell">
                             <a href="EnketoFormServlet?formLayoutId=<c:out value="${dedc.edc.defaultVersionId}"/>&studyEventId=<c:out value="${studyEvent.id}"/>&eventCrfId=<c:out value="${dedc.eventCRF.id}"/>&originatingPage=<c:out value="${originatingPage}"/>&mode=<c:out value="edit"/>"
                             onMouseDown="javascript:setImage('bt_EnterData<c:out value="${rowCount}"/>','images/bt_EnterData_d.gif');"
                             onMouseUp="javascript:setImage('bt_EnterData<c:out value="${rowCount}"/>','images/bt_EnterData.gif');"
                             ><span name="bt_EnterData<c:out value="${rowCount}"/>" class="icon icon-pencil-squared" border="0" alt="<fmt:message key="enter_data" bundle="${resword}"/>" title="<fmt:message key="enter_data" bundle="${resword}"/>" align="left" hspace="2"></a>&nbsp;
-                    </td>
                     </c:when>
 
                     <c:otherwise></c:otherwise>
                     </c:choose>
-                    <td class="table_cell">
                                    <a href="EnketoFormServlet?formLayoutId=<c:out value="${dedc.edc.defaultVersionId}"/>&studyEventId=<c:out value="${studyEvent.id}"/>&eventCrfId=<c:out value="${dedc.eventCRF.id}"/>&originatingPage=<c:out value="${originatingPage}"/>&mode=<c:out value="view"/>"
-                      onMouseDown="javascript:setImage('bt_View1','images/bt_View_d.gif');"
-                      onMouseUp="javascript:setImage('bt_View1','images/bt_View.gif');"><span
-                      name="bt_View1" align="left" class="icon icon-search" border="0" alt="<fmt:message key="view_default" bundle="${resword}"/>" title="<fmt:message key="view_default" bundle="${resword}"/>" hspace="2"></a>&nbsp;
-                  </td>
+                      onMouseDown="javascript:setImage('bt_View','images/bt_View_d.gif');"
+                      onMouseUp="javascript:setImage('bt_View','images/bt_View.gif');"><span
+                      name="bt_View" align="left" class="icon icon-search" border="0" alt="<fmt:message key="view_data" bundle="${resword}"/>" title="<fmt:message key="view_data" bundle="${resword}"/>" hspace="2"></a>&nbsp;
                   </tr>
                     </table>
 
@@ -524,9 +520,9 @@
 
                         <c:when test='${actionQuery == ""}'>
                                    <a href="EnketoFormServlet?formLayoutId=<c:out value="${dec.eventCRF.formLayout.id}"/>&studyEventId=<c:out value="${studyEvent.id}"/>&eventCrfId=<c:out value="${dec.eventCRF.id}"/>&originatingPage=<c:out value="${originatingPage}"/>&mode=<c:out value="view"/>"
-                                onMouseDown="javascript:setImage('bt_View1','images/bt_View_d.gif');"
-                                onMouseUp="javascript:setImage('bt_View1','images/bt_View.gif');"
-                                ><span name="bt_View1" class="icon icon-search" border="0" alt="<fmt:message key="view" bundle="${resword}"/>" title="<fmt:message key="view" bundle="${resword}"/>" align="left" hspace="2"></a>
+                                onMouseDown="javascript:setImage('bt_View','images/bt_View_d.gif');"
+                                onMouseUp="javascript:setImage('bt_View','images/bt_View.gif');"
+                                ><span name="bt_View" class="icon icon-search" border="0" alt="<fmt:message key="view" bundle="${resword}"/>" title="<fmt:message key="view" bundle="${resword}"/>" align="left" hspace="2"></a>
 <!--
                             <a href="javascript:openDocWindow('PrintDataEntry?ecId=<c:out value="${dec.eventCRF.id}"/>')"
                             -->
@@ -541,7 +537,7 @@
                                 ><span name="bt_EnterData<c:out value="${rowCount}"/>" class="icon icon-pencil-squared" border="0" alt="<fmt:message key="enter_data" bundle="${resword}"/>" title="<fmt:message key="enter_data" bundle="${resword}"/>" align="left" hspace="2"></a>&nbsp;
                             </c:if>
                                    <a href="EnketoFormServlet?formLayoutId=<c:out value="${dec.eventCRF.formLayout.id}"/>&studyEventId=<c:out value="${studyEvent.id}"/>&eventCrfId=<c:out value="${dec.eventCRF.id}"/>&originatingPage=<c:out value="${originatingPage}"/>&mode=<c:out value="view"/>"
-                                onMouseDown="javascript:setImage('bt_View<c:out value="${rowCount}"/>','images/bt_View.gif');"
+                                onMouseDown="javascript:setImage('bt_View<c:out value="${rowCount}"/>','images/bt_View_d.gif');"
                                 onMouseUp="javascript:setImage('bt_View<c:out value="${rowCount}"/>','images/bt_View.gif');"
                                 ><span name="bt_View<c:out value="${rowCount}"/>" class="icon icon-search" border="0" alt="<fmt:message key="view_data" bundle="${resword}"/>" title="<fmt:message key="view_data" bundle="${resword}"/>"  hspace="2"></a>&nbsp;
 <!--

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudyEventSigned.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudyEventSigned.jsp
@@ -405,7 +405,7 @@
                                    <a href="EnketoFormServlet?formLayoutId=<c:out value="${dedc.edc.defaultVersionId}"/>&studyEventId=<c:out value="${studyEvent.id}"/>&eventCrfId=<c:out value="${dedc.eventCRF.id}"/>&originatingPage=<c:out value="${originatingPage}"/>&mode=<c:out value="view"/>"
                       onMouseDown="javascript:setImage('bt_View','images/bt_View_d.gif');"
                       onMouseUp="javascript:setImage('bt_View','images/bt_View.gif');"><span
-                      name="bt_View" align="left" class="icon icon-search" border="0" alt="<fmt:message key="view_data" bundle="${resword}"/>" title="<fmt:message key="view_data" bundle="${resword}"/>" hspace="2"></a>&nbsp;
+                      name="bt_View" align="left" class="icon icon-search" border="0" alt="<fmt:message key="view_default" bundle="${resword}"/>" title="<fmt:message key="view_default" bundle="${resword}"/>" hspace="2"></a>&nbsp;
                   </tr>
                     </table>
 


### PR DESCRIPTION
Fixes for the following features:
The query count should reflect only the last entry for each query 
The Sign Subject page Edit and View links give me oops pages for a form that is not yet started. 
Sign Subject page table structure needs to be fixed.
Sign Event page issues are not as bad, but ideally will be fixed.