### PR TITLE
Edit Manual Testing/Bug Fixing - Misc Cosmetic Issues (29/11/17 progress)

### DIFF
--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/showEventByDefinitionRow.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/showEventByDefinitionRow.jsp
@@ -20,7 +20,7 @@
     <tr valign="top">  
    </c:otherwise>   
    </c:choose>    
-      <td class="table_cell_left"><c:out value="${currRow.bean.id}"/></td>
+      <td class="table_cell_left"><c:out value="${currRow.bean.studySubject.label}"/></td>
 
       <td class="table_cell">
       <c:choose>

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudySubject.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudySubject.jsp
@@ -76,7 +76,7 @@
 <c:choose>
 <c:when test="${userBean.techAdmin || userBean.sysAdmin || userRole.manageStudy || userRole.investigator
     || (study.parentStudyId > 0 && userRole.researchAssistant ||study.parentStudyId > 0 && userRole.researchAssistant2)}">
-     <div style="width: 550px">
+     <div style="width: 850px">
     <div class="box_T"><div class="box_L"><div class="box_R"><div class="box_B"><div class="box_TL"><div class="box_TR"><div class="box_BL"><div class="box_BR">
 
     <div class="tablebox_center">


### PR DESCRIPTION
 The Subject ID message still overlaps if a duplicate value is entered (see screenshot I just added here). The other error messages do not appear to overlap.
before:
![before overlap](https://user-images.githubusercontent.com/16472454/33366162-02e1180a-d51d-11e7-82ee-302eb4654172.png)
after:
![after overlap](https://user-images.githubusercontent.com/16472454/33366172-07991be0-d51d-11e7-9de7-8ed86e773d62.png)
