### PR TITLE
OC-8627 Short and similar item names in the same form can create mismatch values in Print Crf HTML format in some cases.

### DIFF
--- a/web/src/main/webapp/js/com/openclinica/renderer/ItemDefRenderer.js
+++ b/web/src/main/webapp/js/com/openclinica/renderer/ItemDefRenderer.js
@@ -26,18 +26,21 @@ function ItemDefRenderer(json, itemDetails, mandatory, formOID, repeatRowNumber,
   this.itemNameLink = undefined;
   this.studyEventOID = studyEventOID;
   this.studyEventRepeatKey = studyEventRepeatKey;
+  this.dash="-";
+  this.key=this.studyEventOID+this.dash+this.studyEventRepeatKey+this.dash+this.OID;
+  this.keyAndRepeat=this.key+this.dash+repeatRowNumber;
   
   
   
-  if (this.studyEventOID!=undefined && app_itemValuesMap[this.studyEventOID+this.studyEventRepeatKey+this.OID+repeatRowNumber]) { 
-    this.itemValue = app_itemValuesMap[this.studyEventOID+this.studyEventRepeatKey+this.OID+repeatRowNumber]; 
+  if (this.studyEventOID!=undefined && app_itemValuesMap[this.keyAndRepeat]) { 
+    this.itemValue = app_itemValuesMap[this.keyAndRepeat]; 
     
     }
   
-  if(this.studyEventOID!=undefined && app_displayAudits=='y' && app_audits[this.studyEventOID+this.studyEventRepeatKey+this.OID])
-	    this.audits = app_audits[this.studyEventOID+this.studyEventRepeatKey+this.OID];
-	    if(this.studyEventOID!=undefined && app_displayDNs=='y' && app_dns[this.studyEventOID+this.studyEventRepeatKey+this.OID])
-	    this.dns = app_dns[this.studyEventOID+this.studyEventRepeatKey+this.OID];
+  if(this.studyEventOID!=undefined && app_displayAudits=='y' && app_audits[this.key])
+	    this.audits = app_audits[this.key];
+	    if(this.studyEventOID!=undefined && app_displayDNs=='y' && app_dns[this.key])
+	    this.dns = app_dns[this.key];
   
   
   if (this.responseType!=undefined) {

--- a/web/src/main/webapp/js/com/openclinica/renderer/StudyDataLoader.js
+++ b/web/src/main/webapp/js/com/openclinica/renderer/StudyDataLoader.js
@@ -365,19 +365,21 @@ function StudyDataLoader(study, json) {
 	        for (var j=0;j<itemsData.length;j++) {
 	          var itemValue = itemsData[j]["@Value"];
 	          var itemOID = itemsData[j]["@ItemOID"];
-	          var key = studyEventOID+studyEventRepeatKey+itemOID;
-	          if (key+repeatKey in app_itemValuesMap == false){
-	        	  app_itemValuesMap[key+repeatKey] = {}; 
+	          var dash="-";
+	          var key = studyEventOID+dash+studyEventRepeatKey+dash+itemOID;
+	          var keyAndRepeat = key+dash+repeatKey;
+	          if (keyAndRepeat in app_itemValuesMap == false){
+	        	  app_itemValuesMap[keyAndRepeat] = {}; 
 	        	  
 	          }
 	          if(key in app_audits == false && app_displayAudits=='y')
-	        	  app_audits[studyEventOID+studyEventRepeatKey+itemOID]={};
+	        	  app_audits[key]={};
         	  if(key in app_dns == false && app_displayDNs=='y')
-	          app_dns[studyEventOID+studyEventRepeatKey+itemOID]={};
+	          app_dns[key]={};
 
-        	  app_itemValuesMap[studyEventOID+studyEventRepeatKey+itemOID+repeatKey] = itemValue; 
-if (app_displayAudits =='y')app_audits[studyEventOID+studyEventRepeatKey+itemOID][repeatKey] = itemsData[j]["OpenClinica:AuditLogs"];
-if (app_displayDNs =='y')   app_dns[studyEventOID+studyEventRepeatKey+itemOID][repeatKey] = itemsData[j]["OpenClinica:DiscrepancyNotes"];
+        	  app_itemValuesMap[keyAndRepeat] = itemValue; 
+if (app_displayAudits =='y')app_audits[key][repeatKey] = itemsData[j]["OpenClinica:AuditLogs"];
+if (app_displayDNs =='y')   app_dns[key][repeatKey] = itemsData[j]["OpenClinica:DiscrepancyNotes"];
 	        }
 	      }
 	    

--- a/web/src/main/webapp/js/com/openclinica/renderer/StudyRenderer.js
+++ b/web/src/main/webapp/js/com/openclinica/renderer/StudyRenderer.js
@@ -953,12 +953,11 @@ function StudyRenderer(json) {
 			}
 
 			if (app_displayAudits == 'y' || app_displayDNs == 'y') {
-				if (typeof itemOids === 'undefined'
-						|| itemOids.toString().indexOf(itemDef["@OID"]) < 0) {
+					var index=itemOids.indexOf(itemOID);
+					if (index==-1){
 					logs += this.printItemMetadata(itemGroupName);
 
 					if (app_displayDNs == 'y') {
-
 						logs += this.printDiscrepancies(itemDefRenderer,
 								repeatRowNumber, repeating);
 					}


### PR DESCRIPTION
Short and similar item names in the same form can create mismatch values
in Print Crf HTML format in some cases.