### PR TITLE
OC-8818 Editing a user profile is not reflected in query widget dropdown

### DIFF
--- a/web/src/main/resources/auth0.properties
+++ b/web/src/main/resources/auth0.properties
@@ -13,3 +13,5 @@ auth0.defaultAuth0WebSecurityEnabled: true
 #auth0.signingAlgorithm: HS256
 auth0.signingAlgorithm: RS256
 auth0.publicKeyPath: /WEB-INF/oc4.pem
+auth0.apiClientId: yfyNkw2a1qIjUYXnSt5ZBi0n7Qc2jSi2
+auth0.apiClientSecret: fUEa8UyF3DmlLrJ4Oq8oyQ4WIfXOB91cfBHUL9Z0B7QaoPKOFW8Swt7Yr_uX6zli


### PR DESCRIPTION
OC-8818 Editing a user profile is not reflected in query widget dropdown
- Added two client properties as a default