### PR TITLE
OC-8695 Add Quick Links section to left pane in Runtime and fixed some bugs on sidebar

### DIFF
--- a/web/src/main/resources/org/akaza/openclinica/i18n/words.properties
+++ b/web/src/main/resources/org/akaza/openclinica/i18n/words.properties
@@ -1594,6 +1594,8 @@ purpose = Purpose
 
 question_number_label = Question Number Label
 
+quick_links = Quick Links
+
 re-populated = re-populated
 
 reason_for_change = Reason for Change

--- a/web/src/main/webapp/WEB-INF/jsp/include/sideInfo.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/sideInfo.jsp
@@ -76,11 +76,41 @@
 	</tr>
     <%-- BWP 3098 >> switch displays for Info box--%>
     <tr id="sidebar_Info_closed"<c:if test="${closeInfoShowIcons}">style="display: none"</c:if>>
-		<td class="sidebar_tab">
+		<td class="sidebar_tab" style="border-bottom: 1px solid #999;">
 
 		<a href="javascript:leftnavExpand('sidebar_Info_open'); leftnavExpand('sidebar_Info_closed');"><span class="icon icon-caret-right gray"></span></a>
 
-		Info
+		<fmt:message key="info" bundle="${resword}"/>
+
+		</td>
+	</tr>
+	<tr id="sidebar_Links_open"<c:if test="${!closeQuickLinks}">style="display: none"</c:if>>
+		<td class="sidebar_tab">
+
+		<a href="javascript:leftnavExpand('sidebar_Links_open'); leftnavExpand('sidebar_Links_closed');">
+               <span class="icon icon-caret-down gray"></span>
+		</a>
+
+		<fmt:message key="quick_links" bundle="${resword}"/>
+
+		<div class="sidebar_tab_content">
+
+			<span style="color: #789EC5">
+			<c:url var="viewNotes" value="/ViewNotes"/>
+	    <a href="${viewNotes}?module=submit&listNotes_f_discrepancyNoteBean.user=<c:out value="${userBean.name}"/>"><fmt:message key="notes_assigned_to_me" bundle="${restext}"/></a>
+
+   	</div>
+
+		</td>
+	</tr>
+	</tr>
+    <%-- OC-8695 --%>
+    <tr id="sidebar_Links_closed"<c:if test="${closeQuickLinks}">style="display: none"</c:if>>
+		<td class="sidebar_tab">
+
+		<a href="javascript:leftnavExpand('sidebar_Links_open'); leftnavExpand('sidebar_Links_closed');"><span class="icon icon-caret-right gray"></span></a>
+
+		<fmt:message key="quick_links" bundle="${resword}"/>
 
 		</td>
 	</tr>
@@ -179,7 +209,6 @@
 	<a href="RequestPassword"><fmt:message key="forgot_password" bundle="${resword}"/></a>
 </c:otherwise>
 </c:choose>
-
 
 <!-- End Sidebar Contents -->
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/restoreStudySubject.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/restoreStudySubject.jsp
@@ -29,7 +29,7 @@
 	<tr id="sidebar_Instructions_closed" style="display: none">
 		<td class="sidebar_tab">
 
-		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span clss="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><span class="icon icon-caret-right gray" border="0" align="right" hspace="10"></span></a>
 
 		<fmt:message key="instructions" bundle="${resword}"/>
 

--- a/web/src/main/webapp/WEB-INF/jsp/submit/createNewStudyEvent.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/createNewStudyEvent.jsp
@@ -133,10 +133,12 @@
       if (objLeftNavRowElement.style) { objLeftNavRowElement = objLeftNavRowElement.style; }
         objLeftNavRowElement.display = (objLeftNavRowElement.display == "none" ) ? "" : "none";
         objExCl = MM_findObj("excl_"+strLeftNavRowElementName);
-        if(objLeftNavRowElement.display == "none"){
-            objExCl.src = "images/bt_Expand.gif";
-        }else{
-            objExCl.src = "images/bt_Collapse.gif";
+        if (objExCl) {
+	        if(objLeftNavRowElement.display == "none"){
+	            objExCl.src = "images/bt_Expand.gif";
+	        }else{
+	            objExCl.src = "images/bt_Collapse.gif";
+	        }
         }
       }
     }


### PR DESCRIPTION
- Bug on Instruction link(sidebar) after clicked(missing arrow and cannot be clicked anymore) on RestoreStudySubject page
![screenshot from 2018-08-07 17-53-47](https://user-images.githubusercontent.com/13865076/43769059-735cdaf6-9a6b-11e8-9c36-6abbf0d73568.png)

- Bug on sidebar(dobel link show up after open) on CreateNewStudyEvent page (Task > Schedule Event)
![screenshot from 2018-08-07 17-54-22](https://user-images.githubusercontent.com/13865076/43769178-b7df8c1e-9a6b-11e8-86bf-f6b65376e881.png)
