### PR TITLE
OC-9391 OC is not properly displaying the warning text in the Add Participant modal when a user tries to exceed a Participant Cap in a browser not at full size

### DIFF
--- a/web/src/main/webapp/includes/styles.css
+++ b/web/src/main/webapp/includes/styles.css
@@ -838,7 +838,6 @@ div#subjectSDV table#sdv {
 }
 
 .alert.small {
-  line-height: 3px;
   margin-bottom: 10px;
   font-size: small;
   text-align: left;


### PR DESCRIPTION
I see there already prevented action that would hide "Add new participant link" if already over the cap. In case  user can access the "Add new participant link", it'll look like this 
![screenshot from 2018-08-07 20-47-45](https://user-images.githubusercontent.com/13865076/43777596-db543ed2-9a85-11e8-913e-4a370e2b7315.png)

Or directly access the link (/AddNewSubject), will look like this
![screenshot from 2018-08-07 20-46-56](https://user-images.githubusercontent.com/13865076/43777666-0d152350-9a86-11e8-98ea-ae352e7dd1a8.png)
