### PR TITLE
Migrating fix from OC 3.14 - OC-8141: XML extract itemgroupdata issue using PGSQL 9.5

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/dao/extract/OdmExtractDAO.java
+++ b/core/src/main/java/org/akaza/openclinica/dao/extract/OdmExtractDAO.java
@@ -3627,7 +3627,8 @@ public class OdmExtractDAO extends DatasetDAO {
         return "select cvit.*, mu.oc_oid as mu_oid from ("
                 + this.getEventGroupItemSqlSS(studyIds, sedIds, itemIds, dateConstraint, datasetItemStatusId, studySubjectIds)
                 + " )cvit left join (select item.item_id, mu.oc_oid from versioning_map vm, item, measurement_unit mu where vm.item_id in " + itemIds
-                + " and vm.item_id = item.item_id and item.units = mu.name )mu on cvit.item_id = mu.item_id";
+                + " and vm.item_id = item.item_id and item.units = mu.name )mu on cvit.item_id = mu.item_id"
+                + " ORDER BY cvit.event_crf_id, cvit.item_group_id, cvit.item_id, cvit.item_data_ordinal";
     }
 
     protected String getItemGroupAndItemMetaWithUnitSql(String crfVersionIds) {


### PR DESCRIPTION
Migrating fix from OC 3.14 - OC-8141: XML extract itemgroupdata issue using PGSQL 9.5