### PR TITLE
OC-9948 Forms are not available on the participate dashboard when the event status is changed from Skipped to Data Entry started

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/UpdateStudyEventServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/UpdateStudyEventServlet.java
@@ -346,7 +346,7 @@ public class UpdateStudyEventServlet extends SecureController {
             studyEvent.setSubjectEventStatus(ses);
             EventCRFDAO ecdao = new EventCRFDAO(sm.getDataSource());
             ArrayList<EventCRFBean> eventCRFs = ecdao.findAllByStudyEvent(studyEvent);
-            if (ses.equals(SubjectEventStatus.SKIPPED) ) {
+            if (ses.equals(SubjectEventStatus.SKIPPED) || ses.equals(SubjectEventStatus.STOPPED) ) {
                 studyEvent.setStatus(Status.UNAVAILABLE);
                 for (int i = 0; i < eventCRFs.size(); i++) {
                     EventCRFBean ecb = eventCRFs.get(i);
@@ -357,8 +357,11 @@ public class UpdateStudyEventServlet extends SecureController {
                     ecdao.update(ecb);
                 }
             } else {
+                studyEvent.setStatus(Status.AVAILABLE);
                 for (int i = 0; i < eventCRFs.size(); i++) {
                     EventCRFBean ecb = eventCRFs.get(i);
+                    ecb.setOldStatus(ecb.getStatus());
+                    ecb.setStatus(Status.AVAILABLE);
                     ecb.setUpdater(ub);
                     ecb.setUpdatedDate(new Date());
                     ecdao.update(ecb);

--- a/web/src/main/java/org/akaza/openclinica/service/ParticipateServiceImpl.java
+++ b/web/src/main/java/org/akaza/openclinica/service/ParticipateServiceImpl.java
@@ -254,7 +254,7 @@ public class ParticipateServiceImpl implements ParticipateService {
 
     private ODMcomplexTypeDefinitionClinicalData generateClinicalData(StudyBean study) {
         ODMcomplexTypeDefinitionClinicalData clinicalData = new ODMcomplexTypeDefinitionClinicalData();
-        clinicalData.setStudyName(study.getName());
+        clinicalData.setStudyName(getParentStudy(study.getOid()).getName());
         clinicalData.setStudyOID(study.getOid());
         return clinicalData;
     }


### PR DESCRIPTION
Forms are not available on the participate dashboard when the event status is changed from Skipped to Data Entry started
Also updated the study/site name in Participate to show always the study name and not the site name.