### PR TITLE
OC-10441 When participant audit log is downloaded in xls format, participant's first name,email and phone number should be masked.

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/ExportExcelStudySubjectAuditLogServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/ExportExcelStudySubjectAuditLogServlet.java
@@ -170,17 +170,8 @@ public class ExportExcelStudySubjectAuditLogServlet extends SecureController {
                     auditBean.setNewValue(Status.get(Integer.parseInt(auditBean.getNewValue())).getName());
                 }
                 if (getAuditLogEventTypes().contains(auditBean.getAuditEventTypeId())) {
-
-                    if ((role.equals(Role.RESEARCHASSISTANT)
-                            && role.getDescription().equals("Clinical Research Coordinator"))
-                            || (role.equals(Role.INVESTIGATOR)
-                            && role.getDescription().equals("Investigator"))) {
-                        auditBean.setOldValue(getCrytoConverter().convertToEntityAttribute(auditBean.getOldValue()));
-                        auditBean.setNewValue(getCrytoConverter().convertToEntityAttribute(auditBean.getNewValue()));
-                    } else {
                         auditBean.setOldValue("<Masked>");
                         auditBean.setNewValue("<Masked>");
-                    }
                 }
             }
             studySubjectAudits.addAll(studySubjectAuditEvents);


### PR DESCRIPTION
When participant audit log is downloaded in xls format, participant's first name,email and phone number should be masked.