### PR TITLE
3.15 1881

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/bean/submit/DisplayItemBean.java
+++ b/core/src/main/java/org/akaza/openclinica/bean/submit/DisplayItemBean.java
@@ -265,6 +265,12 @@ public class DisplayItemBean implements Comparable {
         String valueForDB = "";
         String glue = "";
 
+       // OC-8975 remove current/old value in ResponseSetBean, then update with form value
+        if(rsb.getResponseType().equals(org.akaza.openclinica.bean.core.ResponseType.CHECKBOX) ||
+        		rsb.getResponseType().equals(org.akaza.openclinica.bean.core.ResponseType.SELECTMULTI)) {
+        	rsb.removeSelection();	
+        }
+        
         for (int i = 0; i < values.size(); i++) {
             String value = (String) values.get(i);
 

--- a/web/src/main/java/org/akaza/openclinica/control/submit/VariableSubstitutionHelper.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/VariableSubstitutionHelper.java
@@ -81,6 +81,26 @@ public class VariableSubstitutionHelper {
         tokensMap.put("crfName", encode(section.getCrf().getName()));
         tokensMap.put("crfVersion", encode(section.getCrfVersion().getName()));
 
+		// FR:2019-02-20
+		// event status as code and status name
+		if (event == null) {
+			tokensMap.put("subjectEventStatusCode", "");
+			tokensMap.put("subjectEventStatus", "");
+		} else {
+			tokensMap.put("subjectEventStatusCode", encode(Integer.toString(event.getSubjectEventStatus().getId())));
+			tokensMap.put("subjectEventStatus", encode(event.getSubjectEventStatus().getName()));
+		}
+
+		// FR:2019-02-20
+		// crf status as code and status name
+		if (section.getCrf().getStatus() == null) {
+			tokensMap.put("crfStatusCode", "");
+			tokensMap.put("crfStatus", "");
+		} else {
+			tokensMap.put("crfStatusCode", encode(Integer.toString(section.getCrf().getStatus().getId())));
+			tokensMap.put("crfStatus", encode(section.getCrf().getStatus().getName()));
+		}
+
         // Render a set of "item['ITEM_NAME']" tokens for existing item data
         for (ItemBean item : items) {
 


### PR DESCRIPTION
referencing #1881 this change adds following url tokens:

<table>
<tr><td>subjectEventStatusCode</td><td>code of subject event status</td></tr>
<tr><td>subjectEventStatus</td><td>name of subject event status</td></tr>
<tr><td>crfStatusCode</td><td>code of crf status</td></tr>
<tr><td>crfStatus</td><td>name of crf status</td></tr>
</table>

this enables called web-tools to handle these status too