### PR TITLE
OC-10127 OC Item data table supports 3999 characters in a text field whereas Enketo form seems to fail on 2000 characters limit

### DIFF
--- a/core/src/main/resources/migration/tenant/4.0-2019-04-05-OC-10127.xml
+++ b/core/src/main/resources/migration/tenant/4.0-2019-04-05-OC-10127.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+
+	<changeSet author="jkeremian" id="4.0-2019-04-05-OC-10127-1">
+		<comment>Updating audit_log_event table old-value column size into 4000 character</comment>
+		    <modifyDataType 
+            columnName="old_value"
+            newDataType="varchar(4000)"
+            tableName="audit_log_event"/>
+	</changeSet>
+
+	<changeSet author="jkeremian" id="4.0-2019-04-05-OC-10127-2">
+		<comment>Updating audit_log_event table new-value column size into 4000 character</comment>
+		<modifyDataType
+				columnName="new_value"
+				newDataType="varchar(4000)"
+				tableName="audit_log_event"/>
+	</changeSet>
+
+</databaseChangeLog>

--- a/core/src/main/resources/migration/tenant/release.xml
+++ b/core/src/main/resources/migration/tenant/release.xml
@@ -26,5 +26,6 @@
        <include file="migration/tenant/4.0-2019-02-14-OC-10324.xml"/>
        <include file="migration/tenant/4.0-2019-03-26-OC-10529.xml"/>
        <include file="migration/tenant/4.0-2019-04-01-OC-10483.xml"/>
+       <include file="migration/tenant/4.0-2019-04-05-OC-10127.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
OC Item data table supports 3999 characters in a text field whereas Enketo form seems to fail on 2000 characters limit