### PR TITLE
OC-10631 Wrong user is shown in audit log when PII entered through API, if the participant is already created

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/service/participant/ParticipantServiceImpl.java
+++ b/core/src/main/java/org/akaza/openclinica/service/participant/ParticipantServiceImpl.java
@@ -73,7 +73,8 @@ public class ParticipantServiceImpl implements ParticipantService {
 	@Autowired
 	private UserAccountDAO userAccountDao;
 
-
+    @Autowired
+    private UserAccountDao userAccountHibDao;
 
     @Autowired
     private StudySubjectDao studySubjectHibDao;
@@ -129,8 +130,6 @@ if(studySubjectBean==null || !studySubjectBean.isActive()) {
     studySubjectBean.setOwner(subjectTransfer.getOwner());
     Date now = new Date();
     studySubjectBean.setCreatedDate(now);
-    studySubjectBean.setUpdater(subjectTransfer.getOwner());
-    studySubjectBean.setUpdatedDate(now);
     studySubjectBean = this.getStudySubjectDao().createWithoutGroup(studySubjectBean);
 
 }
@@ -385,16 +384,24 @@ private void updateStudySubjectSize(StudyBean currentStudy) {
         StudySubject studySubject = studySubjectHibDao.findById(studySubjectBean.getId());
 
         StudySubjectDetail studySubjectDetail = studySubject.getStudySubjectDetail();
+        UserAccount userAccount = userAccountHibDao.findById(userAccountBean.getId());
+        studySubject.setUpdateId(userAccount.getUserId());
+        studySubject.setDateUpdated(new Date());
 
         if (studySubjectDetail == null) {
             studySubjectDetail = new StudySubjectDetail();
         }
 
-        studySubjectDetail.setFirstName(subjectTransfer.getFirstName()!=null? subjectTransfer.getFirstName():"");
-        studySubjectDetail.setLastName(subjectTransfer.getLastName()!=null? subjectTransfer.getLastName():"");
-        studySubjectDetail.setEmail(subjectTransfer.getEmailAddress()!=null? subjectTransfer.getEmailAddress():"");
-        studySubjectDetail.setPhone(subjectTransfer.getPhoneNumber()!=null? subjectTransfer.getPhoneNumber():"");
-        studySubjectDetail.setIdentifier(subjectTransfer.getIdentifier()!=null? subjectTransfer.getIdentifier():"");
+        if (subjectTransfer.getFirstName() != null)
+            studySubjectDetail.setFirstName(subjectTransfer.getFirstName() != null ? subjectTransfer.getFirstName() : "");
+        if (subjectTransfer.getLastName() != null)
+            studySubjectDetail.setLastName(subjectTransfer.getLastName() != null ? subjectTransfer.getLastName() : "");
+        if (subjectTransfer.getEmailAddress() != null)
+            studySubjectDetail.setEmail(subjectTransfer.getEmailAddress() != null ? subjectTransfer.getEmailAddress() : "");
+        if (subjectTransfer.getPhoneNumber() != null)
+            studySubjectDetail.setPhone(subjectTransfer.getPhoneNumber() != null ? subjectTransfer.getPhoneNumber() : "");
+        if (subjectTransfer.getIdentifier() != null)
+            studySubjectDetail.setIdentifier(subjectTransfer.getIdentifier() != null ? subjectTransfer.getIdentifier() : "");
 
         studySubject.setStudySubjectDetail(studySubjectDetail);
 

--- a/web/src/main/java/org/akaza/openclinica/controller/UserController.java
+++ b/web/src/main/java/org/akaza/openclinica/controller/UserController.java
@@ -219,7 +219,7 @@ public class UserController {
                 throw new OpenClinicaSystemException(ErrorConstants.ERR_STUDY_TO_SITE_NOT_Valid_OID);
             }
             if (!validateService.isUserHasCrcOrInvestigaterRole(userRoles)) {
-                throw new OpenClinicaSystemException(ErrorConstants.ERR_NO_ROLE_SETUP);
+                throw new OpenClinicaSystemException(ErrorConstants.ERR_NO_SUFFICIENT_PRIVILEGES);
             }
             if (!validateService.isUserRoleHasAccessToSite(userRoles, siteOid)) {
                 throw new OpenClinicaSystemException(ErrorConstants.ERR_NO_ROLE_SETUP);

--- a/web/src/main/java/org/akaza/openclinica/service/ValidateServiceImpl.java
+++ b/web/src/main/java/org/akaza/openclinica/service/ValidateServiceImpl.java
@@ -86,7 +86,7 @@ public class ValidateServiceImpl implements ValidateService {
 
     public boolean isStudyOidValidStudyLevelOid(String studyOid) {
         Study publicStudy = getPublicStudy(studyOid);
-        if (publicStudy.getStudy() == null) {
+        if (publicStudy!=null && publicStudy.getStudy() == null) {
             return true;
         }
         return false;
@@ -102,7 +102,7 @@ public class ValidateServiceImpl implements ValidateService {
 
     public boolean isSiteOidValidSiteLevelOid(String siteOid) {
         Study publicSite = getPublicStudy(siteOid);
-        if (publicSite.getStudy() != null) {
+        if (publicSite!=null && publicSite.getStudy() != null) {
             return true;
         }
         return false;
@@ -112,7 +112,7 @@ public class ValidateServiceImpl implements ValidateService {
     public boolean isStudyToSiteRelationValid(String studyOid, String siteOid) {
         Study publicStudy = getPublicStudy(studyOid);
         Study publicSite = getPublicStudy(siteOid);
-        if (publicSite.getStudy().getStudyId() == publicStudy.getStudyId()) {
+        if (publicStudy!=null && publicSite!=null && publicSite.getStudy().getStudyId() == publicStudy.getStudyId()) {
             return true;
         }
         return false;
@@ -136,8 +136,10 @@ public class ValidateServiceImpl implements ValidateService {
 
     public boolean isUserRoleHasAccessToSite(ArrayList<StudyUserRoleBean> userRoles, String siteOid) {
         Study publicSite = getPublicStudy(siteOid);
+        if(publicSite==null)
+            return false;
         for (StudyUserRoleBean userRole : userRoles) {
-            if (userRole.getStudyId() == publicSite.getStudyId())
+            if ((userRole.getStudyId() == publicSite.getStudyId()) || (userRole.getStudyId()==publicSite.getStudy().getStudyId()))
                 return true;
         }
         return false;


### PR DESCRIPTION
Wrong user is shown in audit log when PII entered through API, if the participant is already created
This PR also includes fixes for the OC-10634 and OC-10636 in addtion to OC-10631