### PR TITLE
OC-10679 Completing an empty form causes a null user_id entry in the auditlog database table

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/controller/openrosa/OpenRosaSubmissionController.java
+++ b/web/src/main/java/org/akaza/openclinica/controller/openrosa/OpenRosaSubmissionController.java
@@ -260,7 +260,8 @@ public class OpenRosaSubmissionController {
         List<EventDefinitionCrf> eventDefinitionCrfs = eventDefinitionCrfDao.findAvailableByStudyEventDefStudy(sed.getStudyEventDefinitionId(),
                 study.getStudyId());
         boolean statusChanged=false;
-
+        studyEvent.setUpdateId(userAccount.getUserId());
+        studyEvent.setDateUpdated(new Date());
         if (studyEvent.getSubjectEventStatusId() != SubjectEventStatus.SIGNED.getCode()) {
             int count = 0;
             for (EventCrf evCrf : eventCrfs) {


### PR DESCRIPTION
Completing an empty form causes a null user_id entry in the auditlog database table