### PR TITLE
Remove unused sun.misc import

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/service/ImportServiceImpl.java
+++ b/web/src/main/java/org/akaza/openclinica/service/ImportServiceImpl.java
@@ -54,7 +54,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
-import sun.misc.FormattedFloatingDecimal;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;


### PR DESCRIPTION
1. The import is unused, so the removal has no effect (actually optimizing, even)
2. Importing sun.* breaks compilation on non-Sun JDK (e.g. OpenJDK)
3. From Sun's Oracle themselves: "Why Developers Should Not Write Programs That Call 'sun' Packages": https://www.oracle.com/technetwork/java/faq-sun-packages-142232.html
