### PR TITLE
OC-10655 Advanced Search Last Name and Secondary ID fields are displaying in Casebook audit log as encrypted values instead of "Masked"

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/bean/extract/odm/ClinicalDataReportBean.java
+++ b/core/src/main/java/org/akaza/openclinica/bean/extract/odm/ClinicalDataReportBean.java
@@ -1021,6 +1021,8 @@ public class ClinicalDataReportBean extends OdmXmlReportBean {
         auditLogEventTypes.add(47);
         auditLogEventTypes.add(49);
         auditLogEventTypes.add(50);
+        auditLogEventTypes.add(53);
+        auditLogEventTypes.add(56);
         return auditLogEventTypes;
     }
 


### PR DESCRIPTION
Advanced Search Last Name and Secondary ID fields are displaying in Casebook audit log as encrypted values instead of "Masked"