### PR TITLE
OC-10926

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/controller/ImportController.java
+++ b/web/src/main/java/org/akaza/openclinica/controller/ImportController.java
@@ -162,14 +162,14 @@ public class ImportController {
         UserAccountBean userAccountBean = utilService.getUserAccountFromRequest(request);
         ArrayList<StudyUserRoleBean> userRoles = userAccountBean.getRoles();
 
+        if (!validateService.isStudyAvailable(studyOid)) {
+            return new ResponseEntity(ErrorConstants.ERR_STUDY_OID_NOT_AVAILABLE, HttpStatus.OK);
+        }
 
         if (!validateService.isStudyOidValid(studyOid)) {
-            return new ResponseEntity(ErrorConstants.ERR_STUDY_NOT_EXIST, HttpStatus.NOT_FOUND);
+            return new ResponseEntity(ErrorConstants.ERR_STUDY_NOT_EXIST, HttpStatus.OK);
         }
 
-        if (!validateService.isStudyAvailable(studyOid)) {
-            return new ResponseEntity(ErrorConstants.ERR_STUDY_NOT_EXIST, HttpStatus.NOT_FOUND);
-        }
 
         if (siteOid != null) {
             if (!validateService.isUserHasAccessToSite(userRoles, siteOid)) {

--- a/web/src/main/java/org/akaza/openclinica/web/restful/errors/ErrorConstants.java
+++ b/web/src/main/java/org/akaza/openclinica/web/restful/errors/ErrorConstants.java
@@ -39,6 +39,8 @@ public class ErrorConstants {
     public static final String ERR_XML_NOT_WELL_FORMED = "errorCode.xmlNotWellFormed";
 
     public static final String ERR_STUDY_NOT_EXIST = "errorCode.studyNotExist";
+    public static final String ERR_STUDY_OID_NOT_AVAILABLE = "errorCode.studyOIDNotAvailable";
+
     public static final String ERR_SITE_NOT_EXIST = "errorCode.siteNotExist";
     public static final String ERR_NO_ROLE_SETUP = "errorCode.noRoleSetUp";
     public static final String ERR_NO_SUFFICIENT_PRIVILEGES = "errorCode.noSufficientPrivileges";
@@ -46,6 +48,9 @@ public class ErrorConstants {
 
     public static final String ERR_NO_SUBJECT_FOUND = "errorCode.noSubjectFound";
     public static final String ERR_EVENT_NOT_EXIST = "errorCode.eventNotExist";
+    public static final String ERR_EVENT_NOT_AVAILABLE = "errorCode.eventNotAvailable";
+    public static final String ERR_FORM_NOT_AVAILABLE = "errorCode.formNotAvailable";
+
     public static final String ERR_NOT_INTEGER = "errorCode.notInteger";
     public static final String ERR_ORDINAL_TOO_BIG = "errorCode.ordinalTooBig";
 


### PR DESCRIPTION
Also include fix for the following tickets:
https://jira.openclinica.com/browse/OC-10926
User can import data on a removed event CRF, with a status of invalid on Participant details page
and
https://jira.openclinica.com/browse/OC-10924  
Error reported on importing to a locked event through API is not correct
and
https://jira.openclinica.com/browse/OC-10880
Add support to validate study / site status in XML import endpoint