### PR TITLE
OC 10446      Bulk participant creation API should reject the file if ParticipantID column is not found or there are more than one ParticipantID columns

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/service/StudyParticipantServiceImpl.java
+++ b/web/src/main/java/org/akaza/openclinica/service/StudyParticipantServiceImpl.java
@@ -109,6 +109,9 @@ public class StudyParticipantServiceImpl implements StudyParticipantService {
         if (StringUtils.isEmpty(addParticipantRequestDTO.getSubjectKey()))
             throw new OpenClinicaSystemException(ErrorConstants.ERR_MISSING_PARTICIPANT_ID_DATA);
 
+        if (!StringUtils.isEmpty(addParticipantRequestDTO.getSubjectKey()) && addParticipantRequestDTO.getSubjectKey() .length() > 30)
+            throw new OpenClinicaSystemException(ErrorConstants.ERR_PARTICIPANT_ID_TOO_LONG);
+
         if (!StringUtils.isEmpty(addParticipantRequestDTO.getFirstName()) && addParticipantRequestDTO.getFirstName().length() > 35)
             throw new OpenClinicaSystemException(ErrorConstants.ERR_FIRST_NAME_TOO_LONG);
 
@@ -179,6 +182,8 @@ public class StudyParticipantServiceImpl implements StudyParticipantService {
                 updateStudySubjectSize(tenantSite,tenantSiteBean);
                 // update at parent level
                 updateStudySubjectSize(tenantStudy,tenantStudyBean);
+        }else{
+            logger.debug("Error message should be here");
         }
 
         if ((register.equalsIgnoreCase("y") || register.equalsIgnoreCase("yes") ) && validateService.isParticipateActive(tenantStudy)) {

--- a/web/src/main/java/org/akaza/openclinica/service/StudyParticipantServiceImpl.java
+++ b/web/src/main/java/org/akaza/openclinica/service/StudyParticipantServiceImpl.java
@@ -182,8 +182,6 @@ public class StudyParticipantServiceImpl implements StudyParticipantService {
                 updateStudySubjectSize(tenantSite,tenantSiteBean);
                 // update at parent level
                 updateStudySubjectSize(tenantStudy,tenantStudyBean);
-        }else{
-            logger.debug("Error message should be here");
         }
 
         if ((register.equalsIgnoreCase("y") || register.equalsIgnoreCase("yes") ) && validateService.isParticipateActive(tenantStudy)) {

--- a/web/src/main/java/org/akaza/openclinica/service/UtilServiceImpl.java
+++ b/web/src/main/java/org/akaza/openclinica/service/UtilServiceImpl.java
@@ -124,7 +124,7 @@ public class UtilServiceImpl implements UtilService {
         return false;
     }
 
-    public void checkFileFormat(MultipartFile file, String fileHeaderMappring) {
+    public void checkFileFormat(MultipartFile file, String fileHeaderMapping) {
         ResponseEntity response = null;
         RestReponseDTO responseDTO = new RestReponseDTO();
         String finalMsg = null;
@@ -140,10 +140,12 @@ public class UtilServiceImpl implements UtilService {
                 try {
                     is = file.getInputStream();
                     reader = new BufferedReader(new InputStreamReader(is));
-                    CSVFormat csvFileFormat = CSVFormat.DEFAULT.withHeader(fileHeaderMappring).withFirstRecordAsHeader().withTrim();
+                    CSVFormat csvFileFormat = CSVFormat.DEFAULT.withHeader(fileHeaderMapping).withFirstRecordAsHeader().withTrim();
 
                     CSVParser csvParser = new CSVParser(reader, csvFileFormat);
                     csvParser.parse(reader, csvFileFormat);
+                } catch (IllegalArgumentException e) {
+                    throw new OpenClinicaSystemException(ErrorConstants.ERR_MULTIPLE_PARTICIPANT_ID_HEADERS);
                 } catch (Exception e) {
                     throw new OpenClinicaSystemException(ErrorConstants.ERR_NOT_CSV_FILE);
                 }

--- a/web/src/main/java/org/akaza/openclinica/web/restful/errors/ErrorConstants.java
+++ b/web/src/main/java/org/akaza/openclinica/web/restful/errors/ErrorConstants.java
@@ -171,6 +171,7 @@ public class ErrorConstants {
     public static final String ERR_FIRST_NAME_TOO_LONG = "errorCode.firstNameTooLong";
     public static final String ERR_LAST_NAME_TOO_LONG = "errorCode.lastNameTooLong";
     public static final String ERR_IDENTIFIER_TOO_LONG = "errorCode.identifierTooLong";
+    public static final String ERR_PARTICIPANT_ID_TOO_LONG = "errorCode.participantIdTooLong";
 
     public static final String ERR_SYSTEM_GENERATED_ID_ENABLED = "errorCode.studyHasSystemGeneratedIdEnabled";
 


### PR DESCRIPTION
    Bulk participant creation API should reject the file if ParticipantID column is not found or there are more than one ParticipantID columns