### PR TITLE
OC-12933 Signature attestation is appearing when form is getting unsigned

### DIFF
--- a/src/main/java/core/org/akaza/openclinica/bean/extract/odm/ClinicalDataReportBean.java
+++ b/src/main/java/core/org/akaza/openclinica/bean/extract/odm/ClinicalDataReportBean.java
@@ -320,8 +320,9 @@ public class ClinicalDataReportBean extends OdmXmlReportBean {
                                 || studyEvent.getWorkflowStatus().equals(StudyEventWorkflowStatusEnum.STOPPED))
                                 && studySubject.getStatus().equals(Status.AVAILABLE)
                                 && studyBean.getStatus().equals(Status.AVAILABLE)
-                                && studyEvent.getSigned() == null && studyEvent.getArchived() == null && studyEvent.getRemoved() == null) {
-                            String signUrl = "/SignStudySubject?id=" + studySubject.getStudySubjectId() + "&seid=" + studyEvent.getStudyEventId();
+                                && !studyEvent.isCurrentlySigned() && !studyEvent.isCurrentlyArchived() && !studyEvent.isCurrentlyRemoved() && !studyEvent.isCurrentlyLocked()) {
+
+                                String signUrl = "/SignStudySubject?id=" + studySubject.getStudySubjectId() + "&seid=" + studyEvent.getStudyEventId();
 
                             xml.append(indent + indent + indent + indent + indent + "<OpenClinica:Link rel=\"sign\" href=\""
                                     + StringEscapeUtils.escapeXml(signUrl) + "\"");

--- a/src/main/java/core/org/akaza/openclinica/bean/extract/odm/ClinicalDataReportBean.java
+++ b/src/main/java/core/org/akaza/openclinica/bean/extract/odm/ClinicalDataReportBean.java
@@ -811,11 +811,11 @@ public class ClinicalDataReportBean extends OdmXmlReportBean {
                 }
                 if (o.length() > 0) {
                     xml.append(nls);
-                    xml.append(currentIndent + "                      OldValue=\"" + StringEscapeUtils.escapeXml(o) + "\" ");
+                    xml.append(currentIndent + "                      OldValue=\"" + org.apache.commons.lang3.StringEscapeUtils.escapeXml11(o) + "\" ");
                 }
                 if (n.length() > 0) {
                     xml.append(nls);
-                    xml.append(currentIndent + "                      NewValue=\"" + StringEscapeUtils.escapeXml(n) + "\"");
+                    xml.append(currentIndent + "                      NewValue=\"" + org.apache.commons.lang3.StringEscapeUtils.escapeXml11(n) + "\"");
                 }
                 if (vt.length() > 0) {
                     xml.append(nls);

--- a/src/main/java/core/org/akaza/openclinica/bean/managestudy/StudyEventBean.java
+++ b/src/main/java/core/org/akaza/openclinica/bean/managestudy/StudyEventBean.java
@@ -428,6 +428,8 @@ public class StudyEventBean extends AuditableEntityBean implements Listener {
 
     public void setSigned(Boolean signed) {
         this.signed = signed;
+        if (signed == Boolean.FALSE)
+            this.setAttestation("");
     }
 
     public StudyEventWorkflowStatusEnum getWorkflowStatus() {

--- a/src/main/java/core/org/akaza/openclinica/domain/datamap/StudyEvent.java
+++ b/src/main/java/core/org/akaza/openclinica/domain/datamap/StudyEvent.java
@@ -47,6 +47,8 @@ public class StudyEvent extends DataMapDomainObject  {
 	private Boolean archived;
 	private Boolean locked;
 	private Boolean signed;
+	private String attestation;
+
 
 	public StudyEvent() {
 	}
@@ -315,6 +317,17 @@ public class StudyEvent extends DataMapDomainObject  {
 
 	public void setSigned(Boolean signed) {
 		this.signed = signed;
+		if (signed == Boolean.FALSE)
+			this.setAttestation("");
+	}
+
+	@Column(name = "attestation")
+	public String getAttestation() {
+		return attestation;
+	}
+
+	public void setAttestation(String attestation) {
+		this.attestation = attestation;
 	}
 
 	@Transient
@@ -333,4 +346,5 @@ public class StudyEvent extends DataMapDomainObject  {
 	public boolean isCurrentlySigned() {
 		return BooleanUtils.isTrue(this.getSigned());
 	}
+
 }

--- a/src/main/java/org/akaza/openclinica/control/managestudy/RestoreStudyEventServlet.java
+++ b/src/main/java/org/akaza/openclinica/control/managestudy/RestoreStudyEventServlet.java
@@ -137,6 +137,9 @@ public class RestoreStudyEventServlet extends SecureController {
             } else {
                 logger.info("submit to restore the event to study");
                 // restore event to study
+                if (event.isSigned()) {
+                    event.setSigned(Boolean.FALSE);
+                }
                 event.setRemoved(Boolean.FALSE);
                 event.setUpdater(ub);
                 event.setUpdatedDate(new Date());


### PR DESCRIPTION
This PR contains fixes for the following stories.
OC-12933 Signature attestation is appearing when form is getting unsigned
OC-10309 When user removes and restores a form under a signed event or the event itself then event should become unsigned
OC-12926 If completed signed common event is removed and then restored, no sign button appears after form is restored