### PR TITLE
OC-12659: Reverted OC-12563 fetching eventCrfs from EventCrfDao

### DIFF
--- a/src/main/java/org/akaza/openclinica/controller/openrosa/OpenRosaSubmissionController.java
+++ b/src/main/java/org/akaza/openclinica/controller/openrosa/OpenRosaSubmissionController.java
@@ -614,7 +614,7 @@ public class OpenRosaSubmissionController {
     }
 
     public void updateStudyEventStatus(Study study, StudySubject studySubject, StudyEventDefinition sed, StudyEvent studyEvent, UserAccount userAccount) {
-        List<EventCrf> eventCrfs = studyEvent.getEventCrfs();
+        List<EventCrf> eventCrfs = eventCrfDao.findByStudyEventIdStudySubjectId(studyEvent.getStudyEventId(), studySubject.getOcOid());
         List<EventDefinitionCrf> eventDefinitionCrfs = eventDefinitionCrfDao.findAvailableByStudyEventDefStudy(sed.getStudyEventDefinitionId(),
                 study.getStudyId());
         studyEvent.setUpdateId(userAccount.getUserId());


### PR DESCRIPTION
Since first Eventcrf is created after studyEvent is fetched from db and hence null when fetched studyEvent.getEventCrfs()