### PR TITLE
OC-9536 Runtime pages load with error about external font resource

### DIFF
--- a/src/main/webapp/includes/styles.css
+++ b/src/main/webapp/includes/styles.css
@@ -1,6 +1,5 @@
 /* Load web fonts */
 @import url("//fonts.googleapis.com/css?family=Didact+Gothic|Open+Sans+Condensed:300,700|Open+Sans:400,400i,600,700,700i");
-@import url('fonts/icomoon.woff?tmrw7y');
 @font-face {
   font-family: 'Courier Prime Code';
   src:  url('fonts/courier-prime-code.ttf') format('truetype');


### PR DESCRIPTION
Remove redundant import that caused log error on console. Font source already handled on icomoon-style.css.
[OC-9536](https://jira.openclinica.com/browse/OC-9536)