### PR TITLE
OC-13088: Removed the Null condition to get all the latest values from userRoles

### DIFF
--- a/src/main/java/org/akaza/openclinica/control/login/ChangeStudyServlet.java
+++ b/src/main/java/org/akaza/openclinica/control/login/ChangeStudyServlet.java
@@ -162,12 +162,8 @@ public class ChangeStudyServlet extends SecureController {
 
     protected void populateCustomUserRoles(CustomRole customRole, String username) {
         List<ChangeStudyDTO> byUser = getStudyDao().findByUser(username);
-        List<StudyEnvironmentRoleDTO> userRoles = (List<StudyEnvironmentRoleDTO>) session.getAttribute("allUserRoles");
-        if (userRoles == null) {
-            logger.error("******************userRoles should not be null");
-            ResponseEntity<List<StudyEnvironmentRoleDTO>> responseEntity = getStudyBuildService().getUserRoles(request, true);
-            userRoles = responseEntity.getBody();
-        }
+        ResponseEntity<List<StudyEnvironmentRoleDTO>> responseEntity = getStudyBuildService().getUserRoles(request, true);
+        List<StudyEnvironmentRoleDTO>  userRoles = responseEntity.getBody();
         if (byUser == null) {
             logger.error("byUser variable should not be null for username:" + username);
         }


### PR DESCRIPTION
In my last PR, When moving the populateCustomUserRoles() from SecureController to ChangeStudyServlet (https://github.com/OpenClinica/OpenClinica/pull/3124), wrongly copied the old code with null condition. So removed it now