### PR TITLE
Merging auth.properties into datainfo.properties

### DIFF
--- a/src/main/java/core/org/akaza/openclinica/dao/core/CoreResources.java
+++ b/src/main/java/core/org/akaza/openclinica/dao/core/CoreResources.java
@@ -113,10 +113,10 @@ public class CoreResources implements InitializingBean {
 
     private void extractMasterKeyCloakConfig(){
         MASTER_KEYCLOAK_CONFIG = new MasterKeycloakConfig();
-        MASTER_KEYCLOAK_CONFIG.setBaseUrl(DATAINFO.getProperty("auth.base-url"));
-        MASTER_KEYCLOAK_CONFIG.setRealm(DATAINFO.getProperty("auth.realm"));
-        MASTER_KEYCLOAK_CONFIG.setClientId(DATAINFO.getProperty("auth.client-id"));
-        MASTER_KEYCLOAK_CONFIG.setClientSecret(DATAINFO.getProperty("auth.client-secret"));
+        MASTER_KEYCLOAK_CONFIG.setBaseUrl(DATAINFO.getProperty("auth.base-url").trim());
+        MASTER_KEYCLOAK_CONFIG.setRealm(DATAINFO.getProperty("auth.realm").trim());
+        MASTER_KEYCLOAK_CONFIG.setClientId(DATAINFO.getProperty("auth.client-id").trim());
+        MASTER_KEYCLOAK_CONFIG.setClientSecret(DATAINFO.getProperty("auth.client-secret").trim());
     }
 
     public static MasterKeycloakConfig getMasterKeyCloakConfig() {

--- a/src/main/java/core/org/akaza/openclinica/dao/core/CoreResources.java
+++ b/src/main/java/core/org/akaza/openclinica/dao/core/CoreResources.java
@@ -8,6 +8,7 @@ import core.org.akaza.openclinica.bean.service.SasProcessingFunction;
 import core.org.akaza.openclinica.bean.service.SqlProcessingFunction;
 import core.org.akaza.openclinica.dao.login.UserAccountDAO;
 import core.org.akaza.openclinica.exception.OpenClinicaSystemException;
+import core.org.akaza.openclinica.web.rest.client.auth.impl.MasterKeycloakConfig;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.keycloak.authorization.client.Configuration;
@@ -46,6 +47,7 @@ public class CoreResources implements InitializingBean {
     private static Properties DATAINFO;
     private static Properties EXTRACTINFO;
     private static KeyCloakConfiguration KEYCLOAKCONFIG;
+    private static MasterKeycloakConfig MASTER_KEYCLOAK_CONFIG;
 
     private static final String DATA_INFO_FILE_NAME = "datainfo.properties";
     private static final String EXTRACT_INFO_FILE_NAME = "extract.properties";
@@ -107,6 +109,18 @@ public class CoreResources implements InitializingBean {
 
     public static Configuration getKeyCloakConfig() {
         return KEYCLOAKCONFIG;
+    }
+
+    private void extractMasterKeyCloakConfig(){
+        MASTER_KEYCLOAK_CONFIG = new MasterKeycloakConfig();
+        MASTER_KEYCLOAK_CONFIG.setBaseUrl(DATAINFO.getProperty("auth.base-url"));
+        MASTER_KEYCLOAK_CONFIG.setRealm(DATAINFO.getProperty("auth.realm"));
+        MASTER_KEYCLOAK_CONFIG.setClientId(DATAINFO.getProperty("auth.client-id"));
+        MASTER_KEYCLOAK_CONFIG.setClientSecret(DATAINFO.getProperty("auth.client-secret"));
+    }
+
+    public static MasterKeycloakConfig getMasterKeyCloakConfig() {
+        return MASTER_KEYCLOAK_CONFIG;
     }
 
     public static void overwriteExternalPropOnInternalProp(Properties internalProp, Properties externalProp) {
@@ -1076,6 +1090,7 @@ public class CoreResources implements InitializingBean {
                 // copyConfig();
             }
             extractKeyCloakConfig();
+            extractMasterKeyCloakConfig();
         } catch (OpenClinicaSystemException e) {
             logger.debug(e.getMessage());
             logger.debug(e.toString());

--- a/src/main/java/core/org/akaza/openclinica/web/rest/client/auth/impl/KeycloakConfig.java
+++ b/src/main/java/core/org/akaza/openclinica/web/rest/client/auth/impl/KeycloakConfig.java
@@ -35,7 +35,7 @@ public class KeycloakConfig {
     @Bean
     public Keycloak Keycloak() {
 
-        Properties authProperties = CoreResources.loadProperties("auth.properties");
+        Properties authProperties = CoreResources.loadProperties("datainfo.properties");
         authBaseUrl= authProperties.getProperty("auth.base-url");
         authRealm= authProperties.getProperty("auth.realm");
         authClientId= authProperties.getProperty("auth.client-id");

--- a/src/main/java/core/org/akaza/openclinica/web/rest/client/auth/impl/KeycloakConfig.java
+++ b/src/main/java/core/org/akaza/openclinica/web/rest/client/auth/impl/KeycloakConfig.java
@@ -22,34 +22,23 @@ import java.util.concurrent.TimeUnit;
 @Configuration
 public class KeycloakConfig {
 
-
-    private String authBaseUrl;
-    private String authRealm;
-    private String authClientId;
-    private String authClientSecret;
-
     private static final int CONNECTION_POOL_SIZE = 10;
     public static final long CONNECTION_TTL = 60000;
     private static final long MIN_TOKEN_VALIDITY = 2000;
 
     @Bean
     public Keycloak Keycloak() {
-
-        Properties authProperties = CoreResources.loadProperties("datainfo.properties");
-        authBaseUrl= authProperties.getProperty("auth.base-url");
-        authRealm= authProperties.getProperty("auth.realm");
-        authClientId= authProperties.getProperty("auth.client-id");
-        authClientSecret= authProperties.getProperty("auth.client-secret");
+        MasterKeycloakConfig masterKeycloakConfig = CoreResources.getMasterKeyCloakConfig();
         ResteasyClient resteasyClient = new ResteasyClientBuilder()
                 .connectionPoolSize(CONNECTION_POOL_SIZE)
                 .connectionTTL(CONNECTION_TTL, TimeUnit.MILLISECONDS)
                 .build();
         Keycloak keycloak = KeycloakBuilder.builder()
-            .serverUrl(authBaseUrl)
-            .clientId(authClientId)
-            .clientSecret(authClientSecret)
+            .serverUrl(masterKeycloakConfig.getBaseUrl())
+            .clientId(masterKeycloakConfig.getClientId())
+            .clientSecret(masterKeycloakConfig.getClientSecret())
             .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
-            .realm(authRealm)
+            .realm(masterKeycloakConfig.getRealm())
             .resteasyClient(resteasyClient)
             .build();
         keycloak

--- a/src/main/java/core/org/akaza/openclinica/web/rest/client/auth/impl/MasterKeycloakConfig.java
+++ b/src/main/java/core/org/akaza/openclinica/web/rest/client/auth/impl/MasterKeycloakConfig.java
@@ -1,0 +1,41 @@
+package core.org.akaza.openclinica.web.rest.client.auth.impl;
+
+public class MasterKeycloakConfig {
+
+    private String baseUrl;
+    private String realm;
+    private String clientId;
+    private String clientSecret;
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public String getRealm() {
+        return realm;
+    }
+
+    public void setRealm(String realm) {
+        this.realm = realm;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public void setClientSecret(String clientSecret) {
+        this.clientSecret = clientSecret;
+    }
+}

--- a/src/main/java/org/akaza/openclinica/config/CustomKeycloakConfigResolver.java
+++ b/src/main/java/org/akaza/openclinica/config/CustomKeycloakConfigResolver.java
@@ -35,7 +35,7 @@ public class CustomKeycloakConfigResolver implements KeycloakConfigResolver {
 
     private KeycloakDeployment resolveDeployment() {
         try {
-            logger.info("Initializing keycloak deployment from keycloak.json");
+            logger.info("Initializing keycloak deployment from datainfo.properties");
             KeycloakDeployment deployment = KeycloakDeploymentBuilder.build(CoreResources.getKeyCloakConfig());
             // Customizing the http client to set time-to-live value on http connections such that they are reinitialized
             // before they get reset by AWS NAT gateway.

--- a/src/main/resources/auth.properties
+++ b/src/main/resources/auth.properties
@@ -1,4 +1,0 @@
-auth.realm: master
-auth.client-id: admin-cli
-auth.client-secret: 3fa0dfb9-43ca-4e74-9a46-4d9fe421ec1a
-auth.base-url: https://auth.openclinica-dev.io/auth

--- a/src/main/resources/datainfo.properties
+++ b/src/main/resources/datainfo.properties
@@ -265,9 +265,6 @@ insight.account.password=somethingsecret
 # Analytics & Adoption Platforms
 #############################################################################
 piwik.url=
-keycloak.realm=
-keycloak.auth-server-url=
-keycloak.credentials.secret=
 encryptionKey=Zq4t7w!z%C&F)J@N
 
 #############################################################################
@@ -277,3 +274,15 @@ enableEmbeddedReports=false
 
 kafka.enabled=false
 kafka.brokers=localhost:9092
+
+#############################################################################
+# Authentication
+#############################################################################
+keycloak.realm=
+keycloak.auth-server-url=
+keycloak.credentials.secret=
+
+auth.realm: master
+auth.client-id: admin-cli
+auth.client-secret:
+auth.base-url: https://auth.openclinica-dev.io/auth


### PR DESCRIPTION
This commit will remove the existing auth.properties file and move it to datainfo.properties.
auth.realm:
auth.client-id:
auth.client-secret:
auth.base-url

I will manually update the datainfo.properties on dev to reflect this change. Staging and production will be scripted.
Devs will have to update their local datainfo.properties.