### PR TITLE
fix OC-13410: Not Started forms missing locked status icon when event…

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/managestudy/signStudySubject.jsp
+++ b/src/main/webapp/WEB-INF/jsp/managestudy/signStudySubject.jsp
@@ -556,7 +556,7 @@
                                 </c:choose>
                               </td>
                               <td>
-                                <c:if test="${studyEvent.locked == true}">
+                                <c:if test="${dse.studyEvent.locked}">
                                     <span class="icon icon-lock-new status" alt="<fmt:message key="locked" bundle="${resword}"/>" title="<fmt:message key="locked" bundle="${resword}"/>"/>
                                 </c:if>
                               </td>


### PR DESCRIPTION
… is locked on Sign Participant page

https://jira.openclinica.com/browse/OC-13410
