### PR TITLE
Because branch 3.15.8 never push to production, so we don't bounce mi…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.akaza.openclinica</groupId>
         <artifactId>OpenClinica</artifactId>
-      <version>3.15.9</version>
+      <version>3.15.8</version>
     </parent>
     <dependencies>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.akaza.openclinica</groupId>
 	<artifactId>OpenClinica</artifactId>
 	<packaging>pom</packaging>
-	<version>3.15.9</version>
+	<version>3.15.8</version>
 	<name>OpenClinica</name>
 	<description>OpenClinica</description>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.akaza.openclinica</groupId>
 		<artifactId>OpenClinica</artifactId>
-		  <version>3.15.9</version>
+		  <version>3.15.8</version>
 	</parent>
 	<dependencies>
 		<dependency>

--- a/ws/pom.xml
+++ b/ws/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.akaza.openclinica</groupId>
         <artifactId>OpenClinica</artifactId>
-       <version>3.15.9</version>
+       <version>3.15.8</version>
     </parent>
     <dependencies>
     	<dependency>


### PR DESCRIPTION
…nor version number after security patch