### PR TITLE
OC-21046 Fix issue where user is unable to edit subject record

### DIFF
--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudySubject.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudySubject.jsp
@@ -87,8 +87,9 @@
 	  	<div class="formfieldXL_BG">
 
 			<c:choose>
-				<c:when test="${study.studyParameterConfig.subjectIdGeneration== 'auto non-editable'}">
-				   <input style="background-color:#D3D3D3;" type="text" name="label" value="<c:out value="${studySub.label}"/>" disabled="disabled" class="formfieldXL">
+				<c:when test="${study.studyParameterConfig.subjectIdGeneration == 'auto non-editable'}">
+					<input type="hidden" name="label" value="<c:out value="${studySub.label}"/>" />
+				   <input style="background-color:#D3D3D3;" type="text" value="<c:out value="${studySub.label}"/>" disabled="disabled" class="formfieldXL">
 					<br />
 				</c:when>    
 				<c:otherwise>
@@ -143,15 +144,18 @@
 
 	<div class="tablebox_center">
 	<table border="0" cellpadding="0" cellspacing="0" width="100%">
-	  <tr valign="top"><td class="table_header_column"><fmt:message key="label" bundle="${resword}"/>:</td><td class="table_cell">
-	  <input type="text" name="label" value="<c:out value="${studySub.label}"/>" disabled="disabled" class="formfieldM">
-	  </td></tr>
-	  <tr valign="top"><td class="table_header_column"><fmt:message key="secondary_ID" bundle="${resword}"/>:</td><td class="table_cell">
-	  <input type="text" name="secondaryLabel" value="<c:out value="${studySub.secondaryLabel}"/>" disabled="disabled" class="formfieldM">
-	  </td></tr>
-	  <tr valign="top"><td class="table_header_column"><fmt:message key="enrollment_date" bundle="${resword}"/>:</td><td class="table_cell">
-	  <input type="text" name="enrollmentDate" value="<c:out value="${enrollDateStr}" />" disabled="disabled" class="formfieldM" id="enrollmentDateField">
-	  </td></tr>
+		<tr valign="top"><td class="table_header_column"><fmt:message key="label" bundle="${resword}"/>:</td><td class="table_cell">
+			<input type="hidden" name="label" value="<c:out value="${studySub.label}"/>" />
+			<input type="text" value="<c:out value="${studySub.label}"/>" disabled="disabled" class="formfieldM">
+		</td></tr>
+		<tr valign="top"><td class="table_header_column"><fmt:message key="secondary_ID" bundle="${resword}"/>:</td><td class="table_cell">
+			<input type="hidden" name="secondaryLabel" value="<c:out value="${studySub.secondaryLabel}"/>" />
+			<input type="text" value="<c:out value="${studySub.secondaryLabel}"/>" disabled="disabled" class="formfieldM">
+		</td></tr>
+		<tr valign="top"><td class="table_header_column"><fmt:message key="enrollment_date" bundle="${resword}"/>:</td><td class="table_cell">
+			<input type="hidden" name="enrollmentDate" value="<c:out value="${enrollDateStr}" />" id="enrollmentDateField" />
+			<input type="text" value="<c:out value="${enrollDateStr}" />" disabled="disabled" class="formfieldM" >
+		</td></tr>
 	 </table>
 
 	 </div>


### PR DESCRIPTION
**Here is a detailed explanation of the issue by ChatGPT**

If you set an input field tag to disabled, it means that the field is not editable or selectable by the user. When a form is submitted, disabled fields are typically not included in the form data sent to the server. This behavior is expected and not specific to Java Spring or the `request#getParameter` function.

The `request#getParameter` function in Java Spring retrieves parameters from the request's query string or form data. Since the disabled input field is not included in the form data, you won't be able to retrieve its value using `request#getParameter`.

If you need to access the value of a disabled input field in your Java Spring application, you can consider using a hidden input field instead. Hidden input fields are not visible to the user but are still submitted with the form data