### PR TITLE
OC-21028 - Fixed - Exporting dataset fails

### DIFF
--- a/core/src/main/resources/migration/3.17/2023-05-19-OC-21028.xml
+++ b/core/src/main/resources/migration/3.17/2023-05-19-OC-21028.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+
+    <changeSet id="2023-05-19-21028-1" author="sqasim">
+        <sql>
+            ALTER TABLE oc_qrtz_job_details
+            ALTER COLUMN job_data TYPE bytea
+            USING E'\\x' || lpad(job_data::text, 2, '0')::bytea;
+        </sql>
+    </changeSet>
+
+    <changeSet id="2023-05-19-21028-2" author="sqasim">
+        <sql>
+            ALTER TABLE oc_qrtz_triggers
+            ALTER COLUMN job_data TYPE bytea
+            USING E'\\x' || lpad(job_data::text, 2, '0')::bytea;
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/core/src/main/resources/migration/3.17/release.xml
+++ b/core/src/main/resources/migration/3.17/release.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+    <include file="migration/3.17/2023-05-19-OC-21028.xml"/>
+</databaseChangeLog>

--- a/core/src/main/resources/migration/master.xml
+++ b/core/src/main/resources/migration/master.xml
@@ -16,5 +16,6 @@
   <include  file="migration/3.11/release.xml"/>  
   <include  file="migration/3.12/release.xml"/>  
   <include  file="migration/3.14/release.xml"/>
+  <include  file="migration/3.17/release.xml"/>
 </databaseChangeLog> 
 

--- a/web/src/main/java/org/akaza/openclinica/control/core/SecureController.java
+++ b/web/src/main/java/org/akaza/openclinica/control/core/SecureController.java
@@ -292,6 +292,9 @@ public abstract class SecureController extends HttpServlet implements SingleThre
                 int state = getScheduler(request).getTriggerState(jobName, groupName);
                 org.quartz.JobDetail details = getScheduler(request).getJobDetail(jobName, groupName);
                 List contexts = getScheduler(request).getCurrentlyExecutingJobs();
+                if (details == null) {
+                    return;
+                }
                 // will we get the above, even if its completed running?
                 // ProcessingResultType message = null;
                 // for (int i = 0; i < contexts.size(); i++) {


### PR DESCRIPTION
- Used the following SQL query to update the data type of `job_data` column from `OID` to `BYTEA` which was required by the Quartz library:
  ```sql
  ALTER TABLE table_name
  ALTER COLUMN job_data TYPE bytea
  USING E'\\x' || lpad(job_data::text, 2, '0')::bytea;
  ```
- Added a check in `SecureController` to ensure that all other pages in the application keep working if exporting the dataset fails. Previously, the other pages were also failing to load when exporting the dataset failed.

https://github.com/OpenClinica/OpenClinica/assets/114670246/25d4caf2-7e86-402e-8a0a-0558a836dcae