### PR TITLE
OC-21090 - Fixed - Creating CRFs is causing Oops error

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -186,8 +186,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>1.4</version>
-			<scope>compile</scope>
+			<version>2.10.0</version>
 		</dependency>
 		<dependency>
 			<groupId>httpunit</groupId>


### PR DESCRIPTION
This started happening after #3580. Fixed by updating `commons-io` and removing the "compile" scope.

https://github.com/OpenClinica/OpenClinica/assets/114670246/24d423e8-f7b4-4ec0-9175-171f6cb3089d

