### PR TITLE
OC-21092 - Removed axis2-saaj library

### DIFF
--- a/ws/pom.xml
+++ b/ws/pom.xml
@@ -72,11 +72,6 @@
 			<version>1.3.2</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.axis2</groupId>
-			<artifactId>axis2-saaj</artifactId>
-			<version>1.7.9</version>
-		</dependency>
-		<dependency>
 			<groupId>cglib</groupId>
 			<artifactId>cglib-nodep</artifactId>
 			<version>2.1_3</version>


### PR DESCRIPTION
- Removed axis2-saaj library as this was added to support SOAP web services on Java 11 but now Java is downgraded back to Java 8 in OC3 and this library was causing an exception `java.lang.NoSuchMethodError: org.apache.ws.commons.schema.XmlSchemaCollection.read(Lorg/xml/sax/InputSource;Lorg/apache/ws/commons/schema/ValidationEventHandler;)Lorg/apache/ws/commons/schema/XmlSchema`. 
- This library was adding `xmlschema-core` as a dependency which caused the above error.