### PR TITLE
OC-21092 - Added axis2-saaj library and excluded axis2-kernel

### DIFF
--- a/ws/pom.xml
+++ b/ws/pom.xml
@@ -72,6 +72,17 @@
 			<version>1.3.2</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.axis2</groupId>
+			<artifactId>axis2-saaj</artifactId>
+			<version>1.7.9</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.axis2</groupId>
+					<artifactId>axis2-kernel</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
 			<groupId>cglib</groupId>
 			<artifactId>cglib-nodep</artifactId>
 			<version>2.1_3</version>


### PR DESCRIPTION
- Removing `axis2-saaj` library caused: `Could not access envelope: Unable to create envelope from given source: ; nested exception is com.sun.xml.messaging.saaj.SOAPExceptionImpl: Unable to create envelope from given source.`. 
- But adding `axis2-saaj` library causes `xmlschema-core` (which is problematic as mentioned in #3605) to be included as well as a dependency of `axis2-kernel` library.
- `axis2-kernel` library has been excluded to ensure that we can use SOAP web services as expected without `Could not access envelope` (caused by removing `axis2-saaj` completely) or `java.lang.NoSuchMethodError: org.apache.ws.commons.schema.XmlSchemaCollection.read(Lorg/xml/sax/InputSource;Lorg/apache/ws/commons/schema/ValidationEventHandler;)Lorg/apache/ws/commons/schema/XmlSchema` (caused by adding `axis2-kernel` as it includes `xmlschema-core`).