### PR TITLE
OC-21092 - Added xercesImpl:2.12.2 to OpenClinica-web

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -276,6 +276,11 @@
             <version>2.4</version>
             <classifier>jdk15</classifier>
         </dependency>
+		<dependency>
+			<groupId>xerces</groupId>
+			<artifactId>xercesImpl</artifactId>
+			<version>2.12.2</version>
+		</dependency>
         <dependency>
             <groupId>xom</groupId>
             <artifactId>xom</artifactId>


### PR DESCRIPTION
Due to an internal issue with the Xerces library, emojis become corrupt. This issue was present in Java 7 (due to xerces present in the JDK) [https://stackoverflow.com/a/31872934](https://stackoverflow.com/a/31872934) but was resolved in Java 8 [https://bugs.openjdk.org/browse/JDK-8058175](https://bugs.openjdk.org/browse/JDK-8058175). However, OC3 still has this problem as it is using _xercesImpl:2.4.0_ which has this problem due to the buffer not being cleared.