### PR TITLE
OC-21264 Change frozen study and site permissions to open forms in different modes

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/service/ValidateService.java
+++ b/core/src/main/java/org/akaza/openclinica/service/ValidateService.java
@@ -1,0 +1,12 @@
+package org.akaza.openclinica.service;
+
+import javax.servlet.http.HttpServletRequest;
+
+public interface ValidateService {
+    /**
+    * This function checks whether the user is study-level or site-level
+    * @param request;
+    * @return true or false;
+    **/
+    boolean isStudyLevelUser(HttpServletRequest request);
+}

--- a/core/src/main/java/org/akaza/openclinica/service/ValidateServiceImpl.java
+++ b/core/src/main/java/org/akaza/openclinica/service/ValidateServiceImpl.java
@@ -1,0 +1,33 @@
+package org.akaza.openclinica.service;
+
+import org.akaza.openclinica.bean.login.StudyUserRoleBean;
+import org.akaza.openclinica.bean.login.UserAccountBean;
+import org.akaza.openclinica.bean.managestudy.StudyBean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+
+public class ValidateServiceImpl implements ValidateService {
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass().getName());
+    public static final String USER_BEAN_NAME = "userBean";
+    public static final String STUDY_NAME = "study";
+
+    public boolean isStudyLevelUser(HttpServletRequest request){
+        StudyBean currentStudy = (StudyBean) request.getSession().getAttribute(STUDY_NAME);
+        UserAccountBean ub = (UserAccountBean) request.getSession().getAttribute(USER_BEAN_NAME);
+        ArrayList studyUserRoles = ub.getRoles();
+        boolean isStudyLevelUser = true;
+        for (int i = 0; i < studyUserRoles.size(); i++) {
+            StudyUserRoleBean studyUserRole = (StudyUserRoleBean) studyUserRoles.get(i);
+            if (studyUserRole.getStudyId() == currentStudy.getId() && currentStudy.getParentStudyId() > 0) {
+                isStudyLevelUser = false;
+                break;
+            }
+        }
+        return isStudyLevelUser;
+    }
+
+}

--- a/core/src/main/resources/org/akaza/openclinica/applicationContext-core-service.xml
+++ b/core/src/main/resources/org/akaza/openclinica/applicationContext-core-service.xml
@@ -123,6 +123,8 @@
         <property name="viewNotesDao" ref="viewNotesDao"/>
     </bean>
 
+    <bean id="validateService" class="org.akaza.openclinica.service.ValidateServiceImpl" />
+
     <bean id="crfLocker" class="org.akaza.openclinica.core.CRFLocker"/>
 
     <bean id = "generateClinicalDataService" class="org.akaza.openclinica.service.extract.GenerateClinicalDataServiceImpl">

--- a/web/src/main/java/org/akaza/openclinica/control/core/CoreSecureController.java
+++ b/web/src/main/java/org/akaza/openclinica/control/core/CoreSecureController.java
@@ -49,6 +49,7 @@ import org.akaza.openclinica.dao.service.StudyParameterValueDAO;
 import org.akaza.openclinica.exception.OpenClinicaException;
 import org.akaza.openclinica.i18n.core.LocaleResolver;
 import org.akaza.openclinica.i18n.util.ResourceBundleProvider;
+import org.akaza.openclinica.service.ValidateService;
 import org.akaza.openclinica.view.BreadcrumbTrail;
 import org.akaza.openclinica.view.Page;
 import org.akaza.openclinica.view.StudyInfoPanel;
@@ -68,6 +69,7 @@ import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.context.support.WebApplicationContextUtils;
 /**
  * Abstract class for creating a controller servlet and extending capabilities of SecureController. However, not using the SingleThreadModel.
  * @author jnyayapathi
@@ -120,6 +122,8 @@ public abstract class CoreSecureController extends HttpServlet {
     private CRFLocker crfLocker;
 
     private DataSource dataSource = null;
+
+    protected ValidateService validateService;
 
     // user is in
 
@@ -1034,23 +1038,18 @@ public abstract class CoreSecureController extends HttpServlet {
         }
     }
 
-    protected static boolean isStudyLevelUser(HttpServletRequest request){
-        StudyBean currentStudy = (StudyBean) request.getSession().getAttribute("study");
-        UserAccountBean ub = (UserAccountBean) request.getSession().getAttribute(USER_BEAN_NAME);
-        ArrayList studyUserRoles = ub.getRoles();
-        boolean isStudyLevelUser = true;
-        for(int i = 0; i < studyUserRoles.size(); i++) {
-            StudyUserRoleBean studyUserRole = (StudyUserRoleBean) studyUserRoles.get(i);
-            if (studyUserRole.getStudyId() == currentStudy.getId() && currentStudy.getParentStudyId() > 0) {
-                isStudyLevelUser = false;
-                break;
-            }
-        }
-        return isStudyLevelUser;
-    }
 
 
     public CRFLocker getCrfLocker() {
         return crfLocker;
     }
+
+    protected ValidateService getValidateService() {
+        if (validateService == null) {
+            validateService = (ValidateService) WebApplicationContextUtils.getWebApplicationContext(
+                    getServletContext()).getBean("validateService");
+        }
+        return validateService;
+    }
+
 }

--- a/web/src/main/java/org/akaza/openclinica/control/core/CoreSecureController.java
+++ b/web/src/main/java/org/akaza/openclinica/control/core/CoreSecureController.java
@@ -1034,6 +1034,21 @@ public abstract class CoreSecureController extends HttpServlet {
         }
     }
 
+    protected static boolean isStudyLevelUser(HttpServletRequest request){
+        StudyBean currentStudy = (StudyBean) request.getSession().getAttribute("study");
+        UserAccountBean ub = (UserAccountBean) request.getSession().getAttribute(USER_BEAN_NAME);
+        ArrayList studyUserRoles = ub.getRoles();
+        boolean isStudyLevelUser = true;
+        for(int i = 0; i < studyUserRoles.size(); i++) {
+            StudyUserRoleBean studyUserRole = (StudyUserRoleBean) studyUserRoles.get(i);
+            if (studyUserRole.getStudyId() == currentStudy.getId() && currentStudy.getParentStudyId() > 0) {
+                isStudyLevelUser = false;
+                break;
+            }
+        }
+        return isStudyLevelUser;
+    }
+
 
     public CRFLocker getCrfLocker() {
         return crfLocker;

--- a/web/src/main/java/org/akaza/openclinica/control/core/SecureController.java
+++ b/web/src/main/java/org/akaza/openclinica/control/core/SecureController.java
@@ -89,6 +89,7 @@ import org.akaza.openclinica.exception.OpenClinicaException;
 import org.akaza.openclinica.i18n.core.LocaleResolver;
 import org.akaza.openclinica.i18n.util.I18nFormatUtil;
 import org.akaza.openclinica.i18n.util.ResourceBundleProvider;
+import org.akaza.openclinica.service.ValidateService;
 import org.akaza.openclinica.service.pmanage.Authorization;
 import org.akaza.openclinica.service.pmanage.ParticipantPortalRegistrar;
 import org.akaza.openclinica.view.BreadcrumbTrail;
@@ -109,6 +110,7 @@ import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.context.support.WebApplicationContextUtils;
 
 /**
  * This class enhances the Controller in several ways.
@@ -207,6 +209,8 @@ public abstract class SecureController extends HttpServlet implements SingleThre
     public static final String MODULE = "module";// to determine which module
 
     private CRFLocker crfLocker;
+
+    protected ValidateService validateService;
 
     // user is in
 
@@ -1231,19 +1235,12 @@ public abstract class SecureController extends HttpServlet implements SingleThre
         return absolutePath;
     }
 
-    protected static boolean isStudyLevelUser(HttpServletRequest request){
-        StudyBean currentStudy = (StudyBean) request.getSession().getAttribute("study");
-        UserAccountBean ub = (UserAccountBean) request.getSession().getAttribute(USER_BEAN_NAME);
-        ArrayList studyUserRoles = ub.getRoles();
-        boolean isStudyLevelUser = true;
-        for(int i = 0; i < studyUserRoles.size(); i++) {
-            StudyUserRoleBean studyUserRole = (StudyUserRoleBean) studyUserRoles.get(i);
-            if (studyUserRole.getStudyId() == currentStudy.getId() && currentStudy.getParentStudyId() > 0) {
-                isStudyLevelUser = false;
-                break;
-            }
+    protected ValidateService getValidateService() {
+        if (validateService == null) {
+            validateService = (ValidateService) WebApplicationContextUtils.getWebApplicationContext(
+                    getServletContext()).getBean("validateService");
         }
-        return isStudyLevelUser;
+        return validateService;
     }
     
 }

--- a/web/src/main/java/org/akaza/openclinica/control/core/SecureController.java
+++ b/web/src/main/java/org/akaza/openclinica/control/core/SecureController.java
@@ -1230,6 +1230,20 @@ public abstract class SecureController extends HttpServlet implements SingleThre
         absolutePath = absolutePath.replaceAll("placeholder.properties", "");
         return absolutePath;
     }
-    
+
+    protected static boolean isStudyLevelUser(HttpServletRequest request){
+        StudyBean currentStudy = (StudyBean) request.getSession().getAttribute("study");
+        UserAccountBean ub = (UserAccountBean) request.getSession().getAttribute(USER_BEAN_NAME);
+        ArrayList studyUserRoles = ub.getRoles();
+        boolean isStudyLevelUser = true;
+        for(int i = 0; i < studyUserRoles.size(); i++) {
+            StudyUserRoleBean studyUserRole = (StudyUserRoleBean) studyUserRoles.get(i);
+            if (studyUserRole.getStudyId() == currentStudy.getId() && currentStudy.getParentStudyId() > 0) {
+                isStudyLevelUser = false;
+                break;
+            }
+        }
+        return isStudyLevelUser;
+    }
     
 }

--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/ResolveDiscrepancyServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/ResolveDiscrepancyServlet.java
@@ -98,7 +98,7 @@ public class ResolveDiscrepancyServlet extends SecureController {
                 Objects.equals(note.getEvent().getSubjectEventStatus(), SubjectEventStatus.STOPPED) ||
                 Objects.equals(note.getEvent().getSubjectEventStatus(), SubjectEventStatus.SKIPPED) ||
                 Objects.equals(note.getEvent().getSubjectEventStatus(), SubjectEventStatus.LOCKED) ||
-                (!isStudyLevelUser(request) && currentStudy.getParentStudyId() > 0 && currentStudy.getStatus().equals(Status.FROZEN)) ||
+                (!getValidateService().isStudyLevelUser(request) && currentStudy.getParentStudyId() > 0 && currentStudy.getStatus().equals(Status.FROZEN)) ||
                 isArchivedCrf ||
                 isDeletedEventorCrf
             ) {
@@ -168,7 +168,7 @@ public class ResolveDiscrepancyServlet extends SecureController {
                 Objects.equals(note.getEvent().getSubjectEventStatus(), SubjectEventStatus.STOPPED) ||
                 Objects.equals(note.getEvent().getSubjectEventStatus(), SubjectEventStatus.SKIPPED) ||
                 Objects.equals(note.getEvent().getSubjectEventStatus(), SubjectEventStatus.LOCKED) ||
-                (!isStudyLevelUser(request) && currentStudy.getParentStudyId() > 0 && currentStudy.getStatus().equals(Status.FROZEN)) ||
+                (!getValidateService().isStudyLevelUser(request) && currentStudy.getParentStudyId() > 0 && currentStudy.getStatus().equals(Status.FROZEN)) ||
                 isArchivedCrf ||
                 isDeletedEventorCrf ||
                 !isCompleted) {

--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/ResolveDiscrepancyServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/ResolveDiscrepancyServlet.java
@@ -93,7 +93,8 @@ public class ResolveDiscrepancyServlet extends SecureController {
 
             if (currentRole.getRole().equals(Role.MONITOR) ||
                 Objects.equals(note.getEvent().getSubjectEventStatus(), SubjectEventStatus.STOPPED) ||
-                Objects.equals(note.getEvent().getSubjectEventStatus(), SubjectEventStatus.SKIPPED)
+                Objects.equals(note.getEvent().getSubjectEventStatus(), SubjectEventStatus.SKIPPED) ||
+                (!isStudyLevelUser(request) && currentStudy.getParentStudyId() > 0 && currentStudy.getStatus().equals(Status.FROZEN))
             ) {
                 return Page.VIEW_SECTION_DATA_ENTRY_SERVLET;
                 // ViewSectionDataEntry?eventDefinitionCRFId=&ecId=1&tabId=1&studySubjectId=1
@@ -159,6 +160,7 @@ public class ResolveDiscrepancyServlet extends SecureController {
             if (currentRole.getRole().equals(Role.MONITOR) ||
                 Objects.equals(note.getEvent().getSubjectEventStatus(), SubjectEventStatus.STOPPED) ||
                 Objects.equals(note.getEvent().getSubjectEventStatus(), SubjectEventStatus.SKIPPED) ||
+                (!isStudyLevelUser(request) && currentStudy.getParentStudyId() > 0 && currentStudy.getStatus().equals(Status.FROZEN)) ||
                 !isCompleted) {
                 StudyEventDAO sedao = new StudyEventDAO(ds);
                 StudyEventBean seb = (StudyEventBean) sedao.findByPK(id);

--- a/web/src/main/java/org/akaza/openclinica/control/submit/InitialDataEntryServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/InitialDataEntryServlet.java
@@ -60,7 +60,7 @@ public class InitialDataEntryServlet extends DataEntryServlet {
     protected void mayProceed(HttpServletRequest request, HttpServletResponse response) throws InsufficientPermissionException {
         mayAccess(request);
         checkStudyLocked(Page.LIST_STUDY_SUBJECTS, respage.getString("current_study_locked"), request, response);
-        if(!isStudyLevelUser(request)){
+        if(!(getValidateService().isStudyLevelUser(request) && ("yes".equalsIgnoreCase((String) request.getAttribute("fromResolvingNotes")) || "yes".equalsIgnoreCase(request.getParameter("fromResolvingNotes"))))){
             checkStudyFrozen(Page.LIST_STUDY_SUBJECTS, respage.getString("current_study_frozen"), request, response);
         }
         this.checkUpdateDataPermission(request);

--- a/web/src/main/java/org/akaza/openclinica/control/submit/InitialDataEntryServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/InitialDataEntryServlet.java
@@ -31,10 +31,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -63,7 +60,9 @@ public class InitialDataEntryServlet extends DataEntryServlet {
     protected void mayProceed(HttpServletRequest request, HttpServletResponse response) throws InsufficientPermissionException {
         mayAccess(request);
         checkStudyLocked(Page.LIST_STUDY_SUBJECTS, respage.getString("current_study_locked"), request, response);
-        checkStudyFrozen(Page.LIST_STUDY_SUBJECTS, respage.getString("current_study_frozen"), request, response);
+        if(!isStudyLevelUser(request)){
+            checkStudyFrozen(Page.LIST_STUDY_SUBJECTS, respage.getString("current_study_frozen"), request, response);
+        }
         this.checkUpdateDataPermission(request);
         
         HttpSession session = request.getSession();

--- a/web/src/main/webapp/WEB-INF/jsp/submit/initialDataEntry.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/initialDataEntry.jsp
@@ -40,6 +40,7 @@
 
 <jsp:useBean scope="request" id="section" class=
   "org.akaza.openclinica.bean.submit.DisplaySectionBean" />
+<jsp:useBean scope="request" id="fromResolvingNotes" class="java.lang.String" />
 
 <%-- set button text depending on whether or not the user is confirming values --%>
 <c:choose>
@@ -96,6 +97,7 @@
 <input type="hidden" name="sectionId" value="<c:out value="${section.section.id}"/>" />
 <input type="hidden" name="checkInputs" value="<c:out value="${checkInputsValue}"/>" />
 <input type="hidden" name="tab" value="<c:out value="${tabId}"/>" />
+<input type="hidden" name="fromResolvingNotes" value="<c:out value="${fromResolvingNotes}"/>" />
 
 
 <c:import url="interviewer.jsp"/>

--- a/web/src/main/webapp/WEB-INF/jsp/submit/initialDataEntryNw.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/initialDataEntryNw.jsp
@@ -20,6 +20,7 @@
 <jsp:useBean scope='request' id='pageMessages' class='java.util.ArrayList'/>
 <jsp:useBean scope='request' id='formMessages' class='java.util.HashMap'/>
 <jsp:useBean scope='request' id='markComplete' class='java.lang.String'/>
+<jsp:useBean scope="request" id="fromResolvingNotes" class="java.lang.String" />
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 
 
@@ -127,6 +128,7 @@
 <input type="hidden" name="sid" value="${section.eventDefinitionCRF.studyId}" />
 <input type="hidden" name="sectionId" value="<c:out value="${section.section.id}"/>" />
 <input type="hidden" name="isFirstTimeOnSection" value="<c:out value="${section.section.id}"/>" />
+<input type="hidden" name="fromResolvingNotes" value="<c:out value="${fromResolvingNotes}"/>" />
 
 <%--FF: ${requestScope['formFirstField']}<br />--%>
 


### PR DESCRIPTION
- Study level users can open completed and data entry started forms in edit mode from discrepancies page at both study and site level.
- Site level users can open forms in any status from discrepancies page in view mode only.
- The above two scenarios hold true if and only if study/site status is set to frozen.