### PR TITLE
OC-21212 fix study metadata wsdl not working

### DIFF
--- a/ws/pom.xml
+++ b/ws/pom.xml
@@ -239,6 +239,11 @@
 			<artifactId>castor-core</artifactId>
 			<version>1.4.1</version>
 		</dependency>
+		<dependency>
+			<groupId>xerces</groupId>
+			<artifactId>xercesImpl</artifactId>
+			<version>2.8.1</version>
+		</dependency>
 	</dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
Here is the error that was being thrown
`<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
   <SOAP-ENV:Header/>
   <SOAP-ENV:Body>
      <SOAP-ENV:Fault>
         <faultcode>SOAP-ENV:Server</faultcode>
         <faultstring xml:lang="en">Could not instantiate serializer org.apache.xml.serialize.XMLSerializer: java.lang.ClassNotFoundException: org.apache.xml.serialize.XMLSerializer</faultstring>
      </SOAP-ENV:Fault>
   </SOAP-ENV:Body>
</SOAP-ENV:Envelope>`

and the following link describes how to fix or why we need to add xerces for castor to work properly.
https://mkyong.com/spring3/classnotfoundexception-org-apache-xml-serialize-xmlserializer/