### PR TITLE
OC-21268 Fix incorrect crf status shown on discrepancies page

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/dao/managestudy/ViewNotesDaoImpl.java
+++ b/core/src/main/java/org/akaza/openclinica/dao/managestudy/ViewNotesDaoImpl.java
@@ -77,6 +77,7 @@ public class ViewNotesDaoImpl extends NamedParameterJdbcDaoSupport implements Vi
             b.setEventName(rs.getString("event_name"));
             b.setEventStart(rs.getDate("date_start"));
             b.setCrfName(rs.getString("crf_name"));
+            b.setEventCRFId(rs.getInt("event_crf_id"));
             int statusId = rs.getInt("status_id");
             if (statusId != 0) {
                 b.setCrfStatus(DataEntryStage.get(statusId).getName());

--- a/core/src/main/resources/migration/3.17/2023-07-06-OC-21268.xml
+++ b/core/src/main/resources/migration/3.17/2023-07-06-OC-21268.xml
@@ -1,0 +1,442 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+
+    <changeSet author="rehman-ali" id="2023-07-06-OC-21268-01" dbms="postgresql" runOnChange="true">
+        <sql>
+            DROP VIEW IF EXISTS dn_age_days;
+            DROP VIEW IF EXISTS	view_site_hidden_event_definition_crf;
+            DROP VIEW IF EXISTS	view_study_hidden_event_definition_crf;
+            DROP VIEW IF EXISTS	view_discrepancy_note;
+            DROP VIEW IF EXISTS view_dn_item_data;
+            DROP VIEW IF EXISTS	view_dn_event_crf;
+            DROP VIEW IF EXISTS view_dn_study_event;
+            DROP VIEW IF EXISTS	view_dn_study_subject;
+            DROP VIEW IF EXISTS view_dn_subject;
+            DROP VIEW IF EXISTS	view_dn_stats;
+        </sql>
+        <rollback>
+            <sql></sql>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="rehman-ali" id="2023-07-06-OC-21268-02" dbms="postgresql" runOnChange="true">
+        <sql>
+            -- View: view_dn_stats
+            -- DROP VIEW view_dn_stats;
+            CREATE OR REPLACE VIEW view_dn_stats AS
+            SELECT dn.discrepancy_note_id,
+            CASE
+            WHEN dn.resolution_status_id = 1 OR dn.resolution_status_id = 2 OR
+            dn.resolution_status_id = 3 THEN DATE_PART('day',current_timestamp -
+            totals.date_updated)
+            ELSE NULL ::integer
+            END AS days,
+            CASE
+            WHEN dn.resolution_status_id = 1 OR dn.resolution_status_id = 2 OR
+            dn.resolution_status_id = 3 THEN DATE_PART('day',current_timestamp -
+            dn.date_created)
+            WHEN dn.resolution_status_id = 4 THEN DATE_PART
+            ('day',totals.date_updated - dn.date_created)
+            ELSE NULL:: integer
+            END AS age, totals.total_notes, dn.date_created, totals.date_updated
+            FROM discrepancy_note dn, ( SELECT dn1.parent_dn_id,
+            max(dn1.date_created) AS date_updated, count(dn1.discrepancy_note_id)
+            AS total_notes
+            FROM discrepancy_note dn1
+            GROUP BY dn1.parent_dn_id) totals
+            WHERE (dn.parent_dn_id IS NULL OR dn.parent_dn_id = 0) AND
+            dn.discrepancy_note_id
+            = totals.parent_dn_id;
+            --------------------------------------------------------------------
+            -- View: dn_age_days
+            -- DROP VIEW dn_age_days;
+            CREATE OR REPLACE VIEW dn_age_days AS
+            SELECT dn.discrepancy_note_id,
+            CASE
+            WHEN dn.resolution_status_id = ANY (ARRAY[1, 2, 3]) THEN DATE_PART
+            ('day',current_timestamp - (( SELECT cdn.date_created
+            FROM discrepancy_note cdn
+            WHERE cdn.discrepancy_note_id = (( SELECT max
+            (idn.discrepancy_note_id) AS max
+            FROM discrepancy_note idn
+            WHERE idn.parent_dn_id = dn.discrepancy_note_id)))))
+            ELSE NULL::integer
+            END AS days,
+            CASE
+            WHEN dn.resolution_status_id = 4 THEN DATE_PART('day',(( SELECT
+            cdn.date_created FROM discrepancy_note cdn WHERE
+            cdn.discrepancy_note_id = ((
+            SELECT max(idn.discrepancy_note_id) AS max
+            FROM discrepancy_note idn WHERE idn.parent_dn_id =
+            dn.discrepancy_note_id)))) - dn.date_created)
+            WHEN dn.resolution_status_id = ANY (ARRAY[1, 2, 3]) THEN DATE_PART
+            ('day',current_timestamp - dn.date_created)
+            ELSE NULL:: integer
+            END AS age
+            FROM discrepancy_note dn
+            WHERE dn.parent_dn_id IS NULL;
+            --------------------------------------------------------------------
+            -- View: view_dn_item_data
+            -- DROP VIEW view_dn_item_data;
+            CREATE OR REPLACE VIEW view_dn_item_data AS
+            SELECT s.study_id, s.parent_study_id, ( SELECT
+            event_definition_crf.hide_crf
+            FROM event_definition_crf
+            WHERE event_definition_crf.study_event_definition_id =
+            sed.study_event_definition_id AND (event_definition_crf.study_id =
+            s.study_id OR
+            event_definition_crf.study_id = s.parent_study_id) AND event_definition_crf.crf_id
+            = c.crf_id AND (event_definition_crf.parent_id = 0 OR
+            event_definition_crf.parent_id IS NULL)) AS study_hide_crf, ( SELECT
+            event_definition_crf.hide_crf
+            FROM event_definition_crf
+            WHERE event_definition_crf.study_event_definition_id =
+            sed.study_event_definition_id AND event_definition_crf.study_id =
+            s.study_id AND
+            event_definition_crf.crf_id = c.crf_id AND (event_definition_crf.parent_id != 0 OR
+            event_definition_crf.parent_id IS NOT NULL)) AS site_hide_crf,
+            dn.discrepancy_note_id, map.item_data_id AS entity_id,
+            map.column_name,
+            ss.study_subject_id, ss.label, ss.status_id AS ss_status_id,
+            dn.discrepancy_note_type_id, dn.resolution_status_id, s.unique_identifier AS
+            site_id, ds.date_created, ds.date_updated, ds.days, ds.age, sed.name AS
+            event_name,
+            se.date_start, c.name AS crf_name, ec.event_crf_id, ec.status_id, i.item_id, i.name AS entity_name,
+            id.value, dn.entity_type, dn.description, dn.detailed_notes,
+            ds.total_notes,
+            ua.first_name, ua.last_name, ua.user_name, ua2.first_name AS owner_first_name,
+            ua2.last_name AS owner_last_name, ua2.user_name AS owner_user_name
+            FROM dn_item_data_map map
+            JOIN discrepancy_note dn ON dn.discrepancy_note_id =
+            map.discrepancy_note_id AND
+            dn.entity_type::text = 'itemData'::text AND (dn.parent_dn_id IS NULL OR
+            dn.parent_dn_id = 0)
+            JOIN view_dn_stats ds ON dn.discrepancy_note_id = ds.discrepancy_note_id
+            JOIN user_account ua2 ON dn.owner_id = ua2.user_id
+            JOIN item_data id ON map.item_data_id = id.item_data_id
+            JOIN item i ON id.item_id = i.item_id
+            JOIN event_crf ec ON id.event_crf_id = ec.event_crf_id
+            JOIN study_event se ON ec.study_event_id = se.study_event_id
+            JOIN crf_version cv ON ec.crf_version_id = cv.crf_version_id
+            JOIN study_event_definition sed ON se.study_event_definition_id =
+            sed.study_event_definition_id
+            JOIN crf c ON cv.crf_id = c.crf_id
+            JOIN study_subject ss ON se.study_subject_id = ss.study_subject_id
+            JOIN study s ON ss.study_id = s.study_id
+            LEFT JOIN user_account ua ON dn.assigned_user_id = ua.user_id
+            WHERE map.study_subject_id = ss.study_subject_id;
+            -----------------------------------------------------------------
+            -- View: view_dn_event_crf
+            -- DROP VIEW view_dn_event_crf;
+            CREATE OR REPLACE VIEW view_dn_event_crf AS
+            SELECT s.study_id, s.parent_study_id, ( SELECT
+            event_definition_crf.hide_crf
+            FROM event_definition_crf
+            WHERE event_definition_crf.study_event_definition_id =
+            sed.study_event_definition_id AND (event_definition_crf.study_id =
+            s.study_id OR
+            event_definition_crf.study_id = s.parent_study_id) AND event_definition_crf.crf_id
+            = c.crf_id AND (event_definition_crf.parent_id = 0 OR
+            event_definition_crf.parent_id IS NULL)) AS study_hide_crf, ( SELECT
+            event_definition_crf.hide_crf
+            FROM event_definition_crf
+            WHERE event_definition_crf.study_event_definition_id =
+            sed.study_event_definition_id AND event_definition_crf.study_id =
+            s.study_id AND
+            event_definition_crf.crf_id = c.crf_id AND (event_definition_crf.parent_id != 0 OR
+            event_definition_crf.parent_id IS NOT NULL)) AS site_hide_crf,
+            dn.discrepancy_note_id, map.event_crf_id AS entity_id,
+            map.column_name,
+            ss.study_subject_id, ss.label, ss.status_id AS ss_status_id,
+            dn.discrepancy_note_type_id, dn.resolution_status_id, s.unique_identifier AS
+            site_id, ds.date_created, ds.date_updated, ds.days, ds.age, sed.name AS
+            event_name,
+            se.date_start, c.name AS crf_name, ec.event_crf_id, ec.status_id, NULL::integer AS item_id,
+            map.column_name AS entity_name,
+            CASE
+            WHEN map.column_name::text = 'date_interviewed'::text THEN to_char
+            (ec.date_interviewed::timestamp with time zone, 'YYYY-MM-DD'::text)
+            WHEN map.column_name::text = 'interviewer_name'::text THEN
+            ec.interviewer_name::text
+            ELSE btrim(''::text)
+            END AS value, dn.entity_type, dn.description, dn.detailed_notes,
+            ds.total_notes, ua.first_name, ua.last_name, ua.user_name,
+            ua2.first_name AS
+            owner_first_name, ua2.last_name AS owner_last_name, ua2.user_name AS
+            owner_user_name
+            FROM dn_event_crf_map map
+            JOIN discrepancy_note dn ON dn.discrepancy_note_id =
+            map.discrepancy_note_id AND
+            dn.entity_type::text = 'eventCrf'::text AND (dn.parent_dn_id IS NULL OR
+            dn.parent_dn_id = 0)
+            JOIN view_dn_stats ds ON dn.discrepancy_note_id = ds.discrepancy_note_id
+            JOIN user_account ua2 ON dn.owner_id = ua2.user_id
+            JOIN event_crf ec ON map.event_crf_id = ec.event_crf_id
+            JOIN study_event se ON ec.study_event_id = se.study_event_id
+            JOIN crf_version cv ON ec.crf_version_id = cv.crf_version_id
+            JOIN study_event_definition sed ON se.study_event_definition_id =
+            sed.study_event_definition_id
+            JOIN crf c ON cv.crf_id = c.crf_id
+            JOIN study_subject ss ON se.study_subject_id = ss.study_subject_id
+            JOIN study s ON ss.study_id = s.study_id
+            LEFT JOIN user_account ua ON dn.assigned_user_id = ua.user_id;
+            --------------------------------------------------------------------
+            -- View: view_dn_study_event
+            -- DROP VIEW view_dn_study_event;
+            CREATE OR REPLACE VIEW view_dn_study_event AS
+            SELECT s.study_id, s.parent_study_id, false AS study_hide_crf, false AS
+            site_hide_crf, dn.discrepancy_note_id, map.study_event_id AS
+            entity_id,
+            map.column_name, ss.study_subject_id, ss.label, ss.status_id AS ss_status_id,
+            dn.discrepancy_note_type_id, dn.resolution_status_id,
+            s.unique_identifier AS
+            site_id, ds.date_created, ds.date_updated, ds.days, ds.age, sed.name AS
+            event_name,
+            se.date_start, btrim(''::text) AS crf_name, 0 AS event_crf_id, 0 AS status_id, NULL::integer AS
+            item_id, map.column_name AS entity_name,
+            CASE
+            WHEN map.column_name::text = 'start_date'::text THEN to_char
+            (se.date_start, 'YYYY-MM-DD'::text)
+            WHEN map.column_name::text = 'end_date'::text THEN to_char(se.date_end,
+            'YYYY-MM-DD'::text)
+            WHEN map.column_name::text = 'location'::text THEN se.location::text
+            ELSE btrim(''::text)
+            END AS value, dn.entity_type, dn.description, dn.detailed_notes,
+            ds.total_notes, ua.first_name, ua.last_name, ua.user_name,
+            ua2.first_name AS
+            owner_first_name, ua2.last_name AS owner_last_name, ua2.user_name AS
+            owner_user_name
+            FROM dn_study_event_map map
+            JOIN discrepancy_note dn ON dn.discrepancy_note_id =
+            map.discrepancy_note_id AND
+            dn.entity_type::text = 'studyEvent'::text AND (dn.parent_dn_id IS NULL OR
+            dn.parent_dn_id = 0)
+            JOIN view_dn_stats ds ON dn.discrepancy_note_id = ds.discrepancy_note_id
+            JOIN user_account ua2 ON dn.owner_id = ua2.user_id
+            JOIN study_event se ON map.study_event_id = se.study_event_id
+            JOIN study_subject ss ON se.study_subject_id = ss.study_subject_id
+            JOIN study s ON ss.study_id = s.study_id
+            JOIN study_event_definition sed ON se.study_event_definition_id =
+            sed.study_event_definition_id
+            LEFT JOIN user_account ua ON dn.assigned_user_id = ua.user_id;
+            ---------------------------------------------------------------------
+            -- View: view_dn_study_subject
+            -- DROP VIEW view_dn_study_subject;
+            CREATE OR REPLACE VIEW view_dn_study_subject AS
+            SELECT s.study_id, s.parent_study_id, false AS study_hide_crf, false AS
+            site_hide_crf, dn.discrepancy_note_id, map.study_subject_id AS
+            entity_id,
+            map.column_name, ss.study_subject_id, ss.label, ss.status_id AS ss_status_id,
+            dn.discrepancy_note_type_id, dn.resolution_status_id,
+            s.unique_identifier AS
+            site_id, ds.date_created, ds.date_updated, ds.days, ds.age, btrim(''::text)
+            AS
+            event_name, NULL::timestamp with time zone AS date_start, btrim(''::text) AS
+            crf_name, 0 AS event_crf_id, 0 AS status_id, NULL::integer AS item_id, map.column_name
+            AS entity_name,
+            to_char(ss.enrollment_date::timestamp with time zone, 'YYYY-MM-DD'::text) AS value,
+            dn.entity_type, dn.description, dn.detailed_notes, ds.total_notes, ua.first_name,
+            ua.last_name, ua.user_name, ua2.first_name AS owner_first_name,
+            ua2.last_name AS
+            owner_last_name, ua2.user_name AS owner_user_name
+            FROM dn_study_subject_map map
+            JOIN discrepancy_note dn ON dn.discrepancy_note_id =
+            map.discrepancy_note_id AND
+            dn.entity_type::text = 'studySub'::text AND (dn.parent_dn_id IS NULL OR
+            dn.parent_dn_id = 0)
+            JOIN view_dn_stats ds ON dn.discrepancy_note_id = ds.discrepancy_note_id
+            JOIN user_account ua2 ON dn.owner_id = ua2.user_id
+            JOIN study_subject ss ON map.study_subject_id = ss.study_subject_id
+            JOIN study s ON ss.study_id = s.study_id
+            LEFT JOIN user_account ua ON dn.assigned_user_id = ua.user_id;
+            -----------------------------------------------------------------
+            -- View: view_dn_subject
+            -- DROP VIEW view_dn_subject;
+            CREATE OR REPLACE VIEW view_dn_subject AS
+            SELECT s.study_id, s.parent_study_id, false AS study_hide_crf, false AS
+            site_hide_crf, dn.discrepancy_note_id, map.subject_id AS entity_id,
+            map.column_name, ss.study_subject_id, ss.label, ss.status_id AS
+            ss_status_id,
+            dn.discrepancy_note_type_id, dn.resolution_status_id, s.unique_identifier AS
+            site_id, ds.date_created, ds.date_updated, ds.days, ds.age, btrim(''::text)
+            AS
+            event_name, NULL::timestamp with time zone AS date_start, btrim(''::text) AS
+            crf_name, 0 AS event_crf_id, 0 AS status_id, NULL::integer AS item_id, map.column_name
+            AS entity_name,
+            CASE
+            WHEN map.column_name::text = 'unique_identifier'::text THEN
+            su.unique_identifier::text
+            WHEN map.column_name::text = 'gender'::text THEN su.gender::text
+            WHEN map.column_name::text = 'date_of_birth'::text THEN to_char
+            (su.date_of_birth::timestamp with time zone, 'YYYY-MM-DD'::text)
+            ELSE btrim(''::text)
+            END AS value, dn.entity_type, dn.description, dn.detailed_notes,
+            ds.total_notes, ua.first_name, ua.last_name, ua.user_name,
+            ua2.first_name AS
+            owner_first_name, ua2.last_name AS owner_last_name, ua2.user_name AS
+            owner_user_name
+            FROM dn_subject_map map
+            JOIN discrepancy_note dn ON dn.discrepancy_note_id =
+            map.discrepancy_note_id AND
+            dn.entity_type::text = 'subject'::text AND (dn.parent_dn_id IS NULL OR
+            dn.parent_dn_id = 0)
+            JOIN view_dn_stats ds ON dn.discrepancy_note_id = ds.discrepancy_note_id
+            JOIN user_account ua2 ON dn.owner_id = ua2.user_id
+            JOIN subject su ON map.subject_id = su.subject_id
+            JOIN study_subject ss ON su.subject_id = ss.subject_id
+            JOIN study s ON ss.study_id = s.study_id
+            LEFT JOIN user_account ua ON dn.assigned_user_id = ua.user_id;
+            --------------------------------------------------------------------
+            -- View: view_site_hidden_event_definition_crf
+            -- DROP VIEW view_site_hidden_event_definition_crf;
+            CREATE OR REPLACE VIEW view_site_hidden_event_definition_crf AS
+            SELECT edc.event_definition_crf_id, edc.hide_crf, edc.study_id,
+            se.study_event_id,
+            cv.crf_version_id
+            FROM event_definition_crf edc
+            JOIN study_event se ON edc.study_event_definition_id =
+            se.study_event_definition_id AND NOT (edc.event_definition_crf_id IN
+            ( SELECT
+            event_definition_crf.parent_id
+            FROM event_definition_crf
+            WHERE event_definition_crf.parent_id IS NOT NULL OR
+            event_definition_crf.parent_id != 0))
+            JOIN crf_version cv ON edc.crf_id = cv.crf_id;
+            ---------------------------------------------------------------
+            -- View: view_study_hidden_event_definition_crf
+            -- DROP VIEW view_study_hidden_event_definition_crf;
+            CREATE OR REPLACE VIEW view_study_hidden_event_definition_crf AS
+            SELECT edc.event_definition_crf_id, edc.hide_crf, edc.study_id,
+            se.study_event_id,
+            cv.crf_version_id
+            FROM event_definition_crf edc
+            JOIN study_event se ON edc.study_event_definition_id =
+            se.study_event_definition_id AND edc.parent_id IS NULL
+            JOIN crf_version cv ON edc.crf_id = cv.crf_id;
+            -----------------------------------------------------------
+            -- View: view_discrepancy_note
+            -- DROP VIEW view_discrepancy_note;
+            CREATE OR REPLACE VIEW view_discrepancy_note AS
+            ( ( ( SELECT view_dn_item_data.study_id,
+            view_dn_item_data.parent_study_id, view_dn_item_data.study_hide_crf,
+            view_dn_item_data.site_hide_crf,
+            view_dn_item_data.discrepancy_note_id,
+            view_dn_item_data.entity_id, view_dn_item_data.column_name,
+            view_dn_item_data.study_subject_id, view_dn_item_data.label,
+            view_dn_item_data.ss_status_id, view_dn_item_data.discrepancy_note_type_id,
+            view_dn_item_data.resolution_status_id, view_dn_item_data.site_id,
+            view_dn_item_data.date_created, view_dn_item_data.date_updated,
+            view_dn_item_data.days, view_dn_item_data.age,
+            view_dn_item_data.event_name,
+            view_dn_item_data.date_start, view_dn_item_data.crf_name,
+            view_dn_item_data.event_crf_id,
+            view_dn_item_data.status_id, view_dn_item_data.item_id,
+            view_dn_item_data.entity_name, view_dn_item_data.value,
+            view_dn_item_data.entity_type, view_dn_item_data.description,
+            view_dn_item_data.detailed_notes, view_dn_item_data.total_notes,
+            view_dn_item_data.first_name, view_dn_item_data.last_name,
+            view_dn_item_data.user_name, view_dn_item_data.owner_first_name,
+            view_dn_item_data.owner_last_name, view_dn_item_data.owner_user_name
+            FROM view_dn_item_data
+            UNION ALL
+            SELECT view_dn_event_crf.study_id,
+            view_dn_event_crf.parent_study_id, view_dn_event_crf.study_hide_crf,
+            view_dn_event_crf.site_hide_crf, view_dn_event_crf.discrepancy_note_id,
+            view_dn_event_crf.entity_id, view_dn_event_crf.column_name,
+            view_dn_event_crf.study_subject_id, view_dn_event_crf.label,
+            view_dn_event_crf.ss_status_id, view_dn_event_crf.discrepancy_note_type_id,
+            view_dn_event_crf.resolution_status_id, view_dn_event_crf.site_id,
+            view_dn_event_crf.date_created, view_dn_event_crf.date_updated,
+            view_dn_event_crf.days, view_dn_event_crf.age,
+            view_dn_event_crf.event_name,
+            view_dn_event_crf.date_start, view_dn_event_crf.crf_name,
+            view_dn_event_crf.event_crf_id,
+            view_dn_event_crf.status_id, view_dn_event_crf.item_id,
+            view_dn_event_crf.entity_name, view_dn_event_crf.value,
+            view_dn_event_crf.entity_type, view_dn_event_crf.description,
+            view_dn_event_crf.detailed_notes, view_dn_event_crf.total_notes,
+            view_dn_event_crf.first_name, view_dn_event_crf.last_name,
+            view_dn_event_crf.user_name, view_dn_event_crf.owner_first_name,
+            view_dn_event_crf.owner_last_name, view_dn_event_crf.owner_user_name
+            FROM view_dn_event_crf)
+            UNION ALL
+            SELECT view_dn_study_event.study_id,
+            view_dn_study_event.parent_study_id, view_dn_study_event.study_hide_crf,
+            view_dn_study_event.site_hide_crf,
+            view_dn_study_event.discrepancy_note_id,
+            view_dn_study_event.entity_id, view_dn_study_event.column_name,
+            view_dn_study_event.study_subject_id, view_dn_study_event.label,
+            view_dn_study_event.ss_status_id,
+            view_dn_study_event.discrepancy_note_type_id,
+            view_dn_study_event.resolution_status_id,
+            view_dn_study_event.site_id,
+            view_dn_study_event.date_created, view_dn_study_event.date_updated,
+            view_dn_study_event.days, view_dn_study_event.age, view_dn_study_event.event_name,
+            view_dn_study_event.date_start, view_dn_study_event.crf_name,
+            view_dn_study_event.event_crf_id,
+            view_dn_study_event.status_id, view_dn_study_event.item_id,
+            view_dn_study_event.entity_name, view_dn_study_event.value,
+            view_dn_study_event.entity_type, view_dn_study_event.description,
+            view_dn_study_event.detailed_notes, view_dn_study_event.total_notes,
+            view_dn_study_event.first_name, view_dn_study_event.last_name,
+            view_dn_study_event.user_name, view_dn_study_event.owner_first_name,
+            view_dn_study_event.owner_last_name,
+            view_dn_study_event.owner_user_name
+            FROM view_dn_study_event)
+            UNION ALL
+            SELECT view_dn_study_subject.study_id,
+            view_dn_study_subject.parent_study_id,
+            view_dn_study_subject.study_hide_crf,
+            view_dn_study_subject.site_hide_crf,
+            view_dn_study_subject.discrepancy_note_id,
+            view_dn_study_subject.entity_id, view_dn_study_subject.column_name,
+            view_dn_study_subject.study_subject_id, view_dn_study_subject.label,
+            view_dn_study_subject.ss_status_id,
+            view_dn_study_subject.discrepancy_note_type_id,
+            view_dn_study_subject.resolution_status_id,
+            view_dn_study_subject.site_id,
+            view_dn_study_subject.date_created, view_dn_study_subject.date_updated,
+            view_dn_study_subject.days, view_dn_study_subject.age,
+            view_dn_study_subject.event_name, view_dn_study_subject.date_start,
+            view_dn_study_subject.crf_name,
+            view_dn_study_subject.event_crf_id,
+            view_dn_study_subject.status_id,
+            view_dn_study_subject.item_id, view_dn_study_subject.entity_name,
+            view_dn_study_subject.value, view_dn_study_subject.entity_type,
+            view_dn_study_subject.description,
+            view_dn_study_subject.detailed_notes,
+            view_dn_study_subject.total_notes, view_dn_study_subject.first_name,
+            view_dn_study_subject.last_name, view_dn_study_subject.user_name,
+            view_dn_study_subject.owner_first_name,
+            view_dn_study_subject.owner_last_name,
+            view_dn_study_subject.owner_user_name
+            FROM view_dn_study_subject)
+            UNION ALL
+            SELECT view_dn_subject.study_id, view_dn_subject.parent_study_id,
+            view_dn_subject.study_hide_crf, view_dn_subject.site_hide_crf,
+            view_dn_subject.discrepancy_note_id, view_dn_subject.entity_id,
+            view_dn_subject.column_name, view_dn_subject.study_subject_id,
+            view_dn_subject.label, view_dn_subject.ss_status_id,
+            view_dn_subject.discrepancy_note_type_id,
+            view_dn_subject.resolution_status_id,
+            view_dn_subject.site_id, view_dn_subject.date_created,
+            view_dn_subject.date_updated, view_dn_subject.days, view_dn_subject.age,
+            view_dn_subject.event_name, view_dn_subject.date_start,
+            view_dn_subject.crf_name,
+            view_dn_subject.event_crf_id,
+            view_dn_subject.status_id, view_dn_subject.item_id, view_dn_subject.entity_name,
+            view_dn_subject.value, view_dn_subject.entity_type,
+            view_dn_subject.description,
+            view_dn_subject.detailed_notes, view_dn_subject.total_notes,
+            view_dn_subject.first_name, view_dn_subject.last_name, view_dn_subject.user_name,
+            view_dn_subject.owner_first_name, view_dn_subject.owner_last_name,
+            view_dn_subject.owner_user_name
+            FROM view_dn_subject;
+        </sql>
+        <rollback>
+            <sql></sql>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/core/src/main/resources/migration/3.17/release.xml
+++ b/core/src/main/resources/migration/3.17/release.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
     <include file="migration/3.17/2023-05-19-OC-21028.xml"/>
+    <include file="migration/3.17/2023-07-06-OC-21268.xml"/>
 </databaseChangeLog>

--- a/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableFactory.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableFactory.java
@@ -21,6 +21,7 @@ import org.akaza.openclinica.bean.managestudy.DiscrepancyNoteBean;
 import org.akaza.openclinica.bean.managestudy.StudyBean;
 import org.akaza.openclinica.bean.managestudy.StudyEventDefinitionBean;
 import org.akaza.openclinica.bean.managestudy.StudySubjectBean;
+import org.akaza.openclinica.bean.submit.EventCRFBean;
 import org.akaza.openclinica.control.AbstractTableFactory;
 import org.akaza.openclinica.control.DefaultActionsEditor;
 import org.akaza.openclinica.control.DropdownFilter;
@@ -168,6 +169,10 @@ public class ListNotesTableFactory extends AbstractTableFactory {
         		getCurrentStudy(),
         		filter,
                 ViewNotesSortCriteria.buildFilterCriteria(limit.getSortSet()));
+        Map<Integer, EventCRFBean> eventCrfCache = new HashMap<>();
+        for (DiscrepancyNoteBean discrepancyNoteBean : items) {
+            discrepancyNoteBean.setCrfStatus(getCrfStatus(eventCrfCache, discrepancyNoteBean));
+        }
         return items;
     }
 
@@ -211,6 +216,7 @@ public class ListNotesTableFactory extends AbstractTableFactory {
         this.setAllNotes(items);
 
         Collection<HashMap<Object, Object>> theItems = new ArrayList<HashMap<Object, Object>>();
+        Map<Integer, EventCRFBean> eventCrfCache = new HashMap<>();
 
         for (DiscrepancyNoteBean discrepancyNoteBean : items) {
 
@@ -229,7 +235,7 @@ public class ListNotesTableFactory extends AbstractTableFactory {
             h.put("eventName", discrepancyNoteBean.getEventName());
             h.put("eventStartDate", discrepancyNoteBean.getEventStart());
             h.put("crfName", discrepancyNoteBean.getCrfName());
-            h.put("crfStatus", discrepancyNoteBean.getCrfStatus());
+            h.put("crfStatus", getCrfStatus(eventCrfCache, discrepancyNoteBean));
             h.put("entityName", discrepancyNoteBean.getEntityName());
             h.put("entityValue", discrepancyNoteBean.getEntityValue());
             h.put("discrepancyNoteBean", discrepancyNoteBean);
@@ -681,6 +687,18 @@ public class ListNotesTableFactory extends AbstractTableFactory {
 
     public DiscrepancyNotesSummary getNotesSummary() {
         return notesSummary;
+    }
+
+    private String getCrfStatus(Map<Integer, EventCRFBean> eventCrfCache, DiscrepancyNoteBean discrepancyNoteBean){
+        EventCRFBean eventCrf;
+        int event_crf_id = discrepancyNoteBean.getEventCRFId();
+        if(eventCrfCache.containsKey(event_crf_id)) {
+            eventCrf = eventCrfCache.get(event_crf_id);
+        } else {
+            eventCrf = (EventCRFBean) getEventCRFDao().findByPK(event_crf_id);
+            eventCrfCache.put(event_crf_id, eventCrf);
+        }
+        return eventCrf.getStage().getName();
     }
 
 }


### PR DESCRIPTION
Previously, we were using `status_id` column from `event_crf` table to compute the status of eventCrf shown on the notes and discrepancies page. That column didn't provide the complete context about status, like in OC3, we have double data entry forms. So, using only `status_id` column couldn't suffice our need for displaying correct `Crf` status that matches the status on `view_subject` page. Now, I have updated the views to return `event_crf_id` as well which would be used to fetch `eventCrf` giving us the complete context of a `Crf` to caculate it status just like it is being done on `view_subject` page. To reduce database calls to fetch `eventCrf`, now we would be caching `eventCrf` against its id.
Note: The motivation behind this logic is OC4 codebase. The same approach is being employed in OC4.