### PR TITLE
OC-21309 Fix item data being set to an incorrect status during form restoration

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/RestoreEventCRFServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/RestoreEventCRFServlet.java
@@ -157,7 +157,7 @@ public class RestoreEventCRFServlet extends SecureController {
                 for (int a = 0; a < itemData.size(); a++) {
                     ItemDataBean item = (ItemDataBean) itemData.get(a);
                     if (item.getStatus().equals(Status.AUTO_DELETED)) {
-                        item.setStatus(Status.AVAILABLE);
+                        item.setStatus(Status.UNAVAILABLE);
                         item.setUpdater(ub);
                         item.setUpdatedDate(new Date());
                         iddao.update(item);


### PR DESCRIPTION
When an item data is created it is set to unavailable status, but during restoration of event_crf, it was being set to available resulting in the issue reported in the ticket where form was not being populated even though the item datas were present in the database.