### PR TITLE
OC-21319 - Remove crf version error

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/bean/admin/NewCRFBean.java
+++ b/core/src/main/java/org/akaza/openclinica/bean/admin/NewCRFBean.java
@@ -661,10 +661,10 @@ public class NewCRFBean extends Object implements java.io.Serializable {
             Collection<QueryObject> values = itemQueries.values();
             for (QueryObject queryObj : values) {
                 qo = queryObj;
-                cur_query = qo.getSql();
-                if (cur_query == null || cur_query.trim().length() < 1) {
+                if (qo == null || qo.getSql() == null || qo.getSql().trim().length() < 1) {
                     continue;
                 }
+                cur_query = qo.getSql();
                 int parCnt = qo.getSqlParameters().size();
                 
                 statement = con.prepareStatement(cur_query);


### PR DESCRIPTION
- NPE was being thrown when uploading a CRF with the same version name as the already uploaded CRF but with some items deleted (or missing).