### PR TITLE
OC-21367 Optimization of repeating group items data saving

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/bean/submit/DisplayItemBean.java
+++ b/core/src/main/java/org/akaza/openclinica/bean/submit/DisplayItemBean.java
@@ -18,9 +18,42 @@ import java.util.ArrayList;
 /**
  * @author ssachs
  */
-public class DisplayItemBean implements Comparable {
+public class DisplayItemBean implements Comparable, Cloneable {
     private ItemDataBean data;
     private ItemBean item;
+
+    public DisplayItemBean(ItemDataBean data, ItemBean item, ItemFormMetadataBean metadata,
+                           String editFlag, ItemDataBean dbData, boolean isNewItem,
+                           String fieldName, int totNew, int totUpdated, int totRes,
+                           int totClosed, int totNA, ArrayList<DiscrepancyNoteBean> discrepancyNotes,
+                           ArrayList children, int numChildren, int numColumns, int numDiscrepancyNotes,
+                           EventDefinitionCRFBean eventDefinitionCRF, int discrepancyNoteStatus, boolean isSCDtoBeShown,
+                           SCDData scdData, boolean blankDwelt, InstantOnChangeFrontStrGroup instantFrontStrGroup) {
+        this.data = data;
+        this.item = item;
+        this.metadata = metadata;
+        this.editFlag = editFlag;
+        this.dbData = dbData;
+        this.isNewItem = isNewItem;
+        this.fieldName = fieldName;
+        this.totNew = totNew;
+        this.totUpdated = totUpdated;
+        this.totRes = totRes;
+        this.totClosed = totClosed;
+        this.totNA = totNA;
+        this.discrepancyNotes = discrepancyNotes;
+        this.children = children;
+        this.numChildren = numChildren;
+        this.numColumns = numColumns;
+        this.numDiscrepancyNotes = numDiscrepancyNotes;
+        this.eventDefinitionCRF = eventDefinitionCRF;
+        this.discrepancyNoteStatus = discrepancyNoteStatus;
+        this.isSCDtoBeShown = isSCDtoBeShown;
+        this.scdData = scdData;
+        this.blankDwelt = blankDwelt;
+        this.instantFrontStrGroup = instantFrontStrGroup;
+    }
+
     private ItemFormMetadataBean metadata;
     private String editFlag = "";// used for items in a group
     private ItemDataBean dbData; // used for DDE, items in a group
@@ -630,4 +663,13 @@ public class DisplayItemBean implements Comparable {
 	public void setFieldName(String fieldName) {
 		this.fieldName = fieldName;
 	}
+
+    @Override
+    public DisplayItemBean clone() {
+        return new DisplayItemBean(this.getData().clone(), this.getItem(), this.getMetadata().clone(), this.getEditFlag(), this.getDbData().clone(), this.getIsNewItem(),
+                this.getFieldName(), this.getTotNew(), this.getTotUpdated(), this.getTotRes(),
+                this.getTotClosed(), this.getTotNA(), this.getDiscrepancyNotes(), this.getChildren(), this.getNumChildren(),
+                this.getNumColumns(), this.getNumDiscrepancyNotes(), this.getEventDefinitionCRF(),
+                this.getDiscrepancyNoteStatus(), this.getIsSCDtoBeShown(), this.getScdData(), this.isBlankDwelt(), this.getInstantFrontStrGroup());
+    }
 }

--- a/core/src/main/java/org/akaza/openclinica/bean/submit/ItemDataBean.java
+++ b/core/src/main/java/org/akaza/openclinica/bean/submit/ItemDataBean.java
@@ -18,7 +18,7 @@ import org.akaza.openclinica.bean.core.AuditableEntityBean;
  *
  *
  */
-public class ItemDataBean extends AuditableEntityBean {
+public class ItemDataBean extends AuditableEntityBean implements Cloneable {
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -31,6 +31,17 @@ public class ItemDataBean extends AuditableEntityBean {
         result = prime * result + (selected ? 1231 : 1237);
         result = prime * result + ((value == null) ? 0 : value.hashCode());
         return result;
+    }
+
+    public ItemDataBean(int eventCRFId, int itemId, ItemBean item, String value, int ordinal, boolean deleted, boolean selected, boolean auditLog) {
+        this.eventCRFId = eventCRFId;
+        this.itemId = itemId;
+        this.item = item;
+        this.value = value;
+        this.ordinal = ordinal;
+        this.deleted = deleted;
+        this.selected = selected;
+        this.auditLog = auditLog;
     }
 
     @Override
@@ -183,5 +194,10 @@ public class ItemDataBean extends AuditableEntityBean {
 	public void setItem(ItemBean item) {
 		this.item = item;
 	}
-    
+
+    @Override
+    public ItemDataBean clone() {
+        return new ItemDataBean(this.getEventCRFId(), this.getItemId(), this.getItem(), this.getValue(),
+                this.getOrdinal(), this.isDeleted(), this.isSelected(), this.isAuditLog());
+    }
 }

--- a/core/src/main/java/org/akaza/openclinica/bean/submit/ItemFormMetadataBean.java
+++ b/core/src/main/java/org/akaza/openclinica/bean/submit/ItemFormMetadataBean.java
@@ -13,7 +13,7 @@ import org.akaza.openclinica.core.form.StringUtil;
 /**
  * @author ssachs
  */
-public class ItemFormMetadataBean extends EntityBean implements Comparable {
+public class ItemFormMetadataBean extends EntityBean implements Comparable, Cloneable {
     //
     private int itemId;
     private int crfVersionId;
@@ -58,6 +58,44 @@ public class ItemFormMetadataBean extends EntityBean implements Comparable {
         result = prime * result + ((subHeader == null) ? 0 : subHeader.hashCode());
         result = prime * result + ((widthDecimal == null) ? 0 : widthDecimal.hashCode());
         return result;
+    }
+
+    public ItemFormMetadataBean(int itemId, int crfVersionId, String header, String subHeader, int parentId, String parentLabel, int columnNumber,
+                                String pageNumberLabel, String questionNumberLabel, String leftItemText, String rightItemText, int sectionId,
+                                int descisionConditionId, int responseSetId, String regexp, String regexpErrorMsg, int ordinal, boolean required,
+                                String defaultValue, String widthDecimal, boolean showItem, String groupLabel, String responseLayout,
+                                String crfVersionName, String crfName, String sectionName, int repeatMax, boolean isHighlighted,
+                                ResponseSetBean responseSet, String conditionalDisplay) {
+        this.itemId = itemId;
+        this.crfVersionId = crfVersionId;
+        this.header = header;
+        this.subHeader = subHeader;
+        this.parentId = parentId;
+        this.parentLabel = parentLabel;
+        this.columnNumber = columnNumber;
+        this.pageNumberLabel = pageNumberLabel;
+        this.questionNumberLabel = questionNumberLabel;
+        this.leftItemText = leftItemText;
+        this.rightItemText = rightItemText;
+        this.sectionId = sectionId;
+        this.descisionConditionId = descisionConditionId;
+        this.responseSetId = responseSetId;
+        this.regexp = regexp;
+        this.regexpErrorMsg = regexpErrorMsg;
+        this.ordinal = ordinal;
+        this.required = required;
+        this.defaultValue = defaultValue;
+        this.widthDecimal = widthDecimal;
+        this.showItem = showItem;
+        this.groupLabel = groupLabel;
+        this.responseLayout = responseLayout;
+        this.crfVersionName = crfVersionName;
+        this.crfName = crfName;
+        this.sectionName = sectionName;
+        this.repeatMax = repeatMax;
+        this.isHighlighted = isHighlighted;
+        this.responseSet = responseSet;
+        this.conditionalDisplay = conditionalDisplay;
     }
 
     @Override
@@ -690,5 +728,15 @@ public class ItemFormMetadataBean extends EntityBean implements Comparable {
             return true;
         }
         return false;
+    }
+
+    @Override
+    public ItemFormMetadataBean clone() {
+        return new ItemFormMetadataBean(this.getItemId(), this.getCrfVersionId(), this.getHeader(), this.getSubHeader(), this.getParentId(),
+                this.getParentLabel(), this.getColumnNumber(), this.getPageNumberLabel(), this.getQuestionNumberLabel(), this.getLeftItemText(),
+                this.getRightItemText(), this.getSectionId(), this.getDescisionConditionId(), this.getResponseSetId(), this.getRegexp(),
+                this.getRegexpErrorMsg(), this.getOrdinal(), this.isRequired(), this.getDefaultValue(), this.getWidthDecimal(), this.isShowItem(),
+                this.getGroupLabel(), this.getResponseLayout(), this.getCrfVersionName(), this.getCrfName(), this.getSectionName(), this.getRepeatMax(),
+                this.isHighlighted(), this.getResponseSet().clone(), this.getConditionalDisplay());
     }
 }

--- a/core/src/main/java/org/akaza/openclinica/bean/submit/ResponseOptionBean.java
+++ b/core/src/main/java/org/akaza/openclinica/bean/submit/ResponseOptionBean.java
@@ -12,7 +12,7 @@ import java.io.Serializable;
 /**
  * @author ssachs
  */
-public class ResponseOptionBean implements Serializable {
+public class ResponseOptionBean implements Serializable, Cloneable {
     /**
      * This will be displayed to the user.
      */
@@ -72,11 +72,22 @@ public class ResponseOptionBean implements Serializable {
         return selected;
     }
 
+    public ResponseOptionBean(String text, String value, boolean selected) {
+        this.text = text;
+        this.value = value;
+        this.selected = selected;
+    }
+
     /**
      * @param selected
      *            The selected to set.
      */
     public void setSelected(boolean selected) {
         this.selected = selected;
+    }
+
+    @Override
+    public ResponseOptionBean clone() {
+        return new ResponseOptionBean(this.getText(), this.getValue(), this.isSelected());
     }
 }

--- a/core/src/main/java/org/akaza/openclinica/bean/submit/ResponseSetBean.java
+++ b/core/src/main/java/org/akaza/openclinica/bean/submit/ResponseSetBean.java
@@ -8,6 +8,8 @@
 package org.akaza.openclinica.bean.submit;
 
 import org.akaza.openclinica.bean.core.EntityBean;
+import org.akaza.openclinica.bean.core.ResponseType;
+import org.apache.commons.collections.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -15,10 +17,18 @@ import java.util.HashMap;
 /**
  * @author ssachs
  */
-public class ResponseSetBean extends EntityBean {
+public class ResponseSetBean extends EntityBean implements Cloneable {
     private int responseTypeId;
 
     private org.akaza.openclinica.bean.core.ResponseType responseType;
+
+    public ResponseSetBean(int responseTypeId, ResponseType responseType, ArrayList options, HashMap optionIndexesByValue, String value) {
+        this.responseTypeId = responseTypeId;
+        this.responseType = responseType;
+        this.options = options;
+        this.optionIndexesByValue = optionIndexesByValue;
+        this.value = value;
+    }
 
     /**
      * A set of options to display to the user. The elements are
@@ -96,6 +106,10 @@ public class ResponseSetBean extends EntityBean {
      */
     public void setResponseTypeId(int responseTypeId) {
         responseType = org.akaza.openclinica.bean.core.ResponseType.get(responseTypeId);
+    }
+
+    public HashMap getOptionIndexesByValue() {
+        return optionIndexesByValue;
     }
 
     public void setOptions(String optionsText, String optionsValues) {
@@ -202,4 +216,22 @@ public class ResponseSetBean extends EntityBean {
         }
         return list;
     }
+
+    @Override
+    public ResponseSetBean clone() {
+        return new ResponseSetBean(this.getResponseTypeId(), this.getResponseType(), this.getClonedOptions(),
+                this.getOptionIndexesByValue(), this.getValue());
+    }
+
+    private ArrayList getClonedOptions(){
+        ArrayList clonedOptions = new ArrayList<>();
+        if(CollectionUtils.isNotEmpty(this.getOptions())){
+            for(int i = 0; i < this.getOptions().size(); i++){
+                ResponseOptionBean option = (ResponseOptionBean) this.getOptions().get(i);
+                clonedOptions.add(option.clone());
+            }
+        }
+        return clonedOptions;
+    }
+
 }

--- a/web/src/main/java/org/akaza/openclinica/control/submit/DataEntryServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/DataEntryServlet.java
@@ -2526,6 +2526,7 @@ public abstract class DataEntryServlet extends CoreSecureController {
         int newDataRowOrdinal = 0;  //holds the ordinal of new data
         int existingGroupSize = dbGroups.size(); //Size of existing repeating data retrieved from database
         ////////////////////////////////////////////////////////////////////////////////////////////
+        List<DisplayItemBean> dibs = FormBeanUtil.getDisplayBeansFromItems(itBeans, getDataSource(), ecb, sb.getId(), nullValuesList, getServletContext());
 
         //Need to go through all of the rows of data
         for (int i = 0; i < repeatMax; i++) {
@@ -2537,7 +2538,6 @@ public abstract class DataEntryServlet extends CoreSecureController {
 
             // want to do deep copy here, so always get a fresh copy for items,
             // may use other better way to do, like clone
-            List<DisplayItemBean> dibs = FormBeanUtil.getDisplayBeansFromItems(itBeans, getDataSource(), ecb, sb.getId(), nullValuesList, getServletContext());
 
             //Process preexisting data marked by the word "manual" from the UI
             if (fp.getStartsWith(igb.getOid() + "_manual" + i + "input")) {
@@ -2547,9 +2547,9 @@ public abstract class DataEntryServlet extends CoreSecureController {
                 formGroup.setInputId(igb.getOid() + "_manual" + i);
                 LOGGER.debug("1: set auto to false for " + igb.getOid() + " " + i);
 
-                dibs = processInputForGroupItem(fp, dibs, i, digb, false);
+                List<DisplayItemBean> clonedDibs = processInputForGroupItem(fp, deepCloneDisplayItems(dibs), i, digb, false);
 
-                formGroup.setItems(dibs);
+                formGroup.setItems(clonedDibs);
                 formGroups.add(formGroup);
                 manualRows++;
             } else if (!StringUtil.isBlank(fp.getString(igb.getOid() + "_manual" + i + ".newRow"))) {
@@ -2562,9 +2562,9 @@ public abstract class DataEntryServlet extends CoreSecureController {
 
                 LOGGER.debug("2: set auto to false for " + igb.getOid() + " " + i);
 
-                dibs = processInputForGroupItem(fp, dibs, i, digb, false);
+                List<DisplayItemBean> clonedDibs = processInputForGroupItem(fp, deepCloneDisplayItems(dibs), i, digb, false);
 
-                formGroup.setItems(dibs);
+                formGroup.setItems(clonedDibs);
                 formGroups.add(formGroup);
                 manualRows++;
             } else if (manualRows == existingGroupSize || isNewRepeatingDataPresent(fp, i, igb)){//process new data or the very first row of data
@@ -5688,10 +5688,10 @@ String tempKey = idb.getItemId()+","+idb.getOrdinal();
             }
             formGroup.setAuto(true);
             LOGGER.debug("1: set auto to TRUE for " + igb.getOid() + " " + i);
-            dibs = processInputForGroupItem(fp, dibs, i, digb, true);
+            List<DisplayItemBean> clonedDibs = processInputForGroupItem(fp, deepCloneDisplayItems(dibs), i, digb, true);
             LOGGER.trace("+++ group ordinal: " + i + " igb name " + igb.getName());
 
-            formGroup.setItems(dibs);
+            formGroup.setItems(clonedDibs);
             //formGroups.add(formGroup);
             return formGroup;
         } else if (!StringUtil.isBlank(fp.getString(igb.getOid() + "_" + i + ".newRow"))) {
@@ -5718,10 +5718,10 @@ String tempKey = idb.getItemId()+","+idb.getOrdinal();
 
             LOGGER.debug("2: set auto to TRUE for " + igb.getOid() + " " + i);
 
-            dibs = processInputForGroupItem(fp, dibs, i, digb, true);
+            List<DisplayItemBean> clonedDibs = processInputForGroupItem(fp, deepCloneDisplayItems(dibs), i, digb, true);
             LOGGER.trace("+++ group ordinal: " + i + " igb name " + igb.getName());
 
-            formGroup.setItems(dibs);
+            formGroup.setItems(clonedDibs);
             //formGroups.add(formGroup);
             return formGroup;
         }
@@ -5736,4 +5736,13 @@ String tempKey = idb.getItemId()+","+idb.getOrdinal();
         }
         return false;
     }
+
+    private List<DisplayItemBean> deepCloneDisplayItems(List<DisplayItemBean> dibs) {
+        List<DisplayItemBean> clonedDibs = new ArrayList<>();
+        for(DisplayItemBean dib: dibs){
+            clonedDibs.add(dib.clone());
+        }
+        return clonedDibs;
+    }
+
 }


### PR DESCRIPTION
`FormBeanUtil#getDisplayBeansFromItems` was being called during the each iteration of the loop, the reason why it was so that a fresh copy of `displayitembeans` was required/used in each iteration but `displayitembeans` were being mutated as well where it was used. Even there was a comment above this method call that said it may be improved by deep copying the `displayitembeans` to prevent making database call again. This code preexitsed before OC-21895 as well. Doing so has tremendously increased the performance for a form having repeating groups no matter whatever the repeat count is. 