### PR TITLE
OC-21463 - Fixed - NullPointerException on saving a form

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/service/rule/expression/ExpressionService.java
+++ b/core/src/main/java/org/akaza/openclinica/service/rule/expression/ExpressionService.java
@@ -461,7 +461,9 @@ public class ExpressionService {
                 String valueFromDb = null;
                 String matchEvents = null;
                 String valueFromForm = null;
-                expression = map.get("expressionWithFixedOrdinals");
+                if (map.get("expressionWithFixedOrdinals") != null) {
+                    expression = map.get("expressionWithFixedOrdinals");
+                }
                 if (checkSyntax(expression)) {
                     valueFromDb = map.get("value");
                     matchEvents = map.get("match");


### PR DESCRIPTION
- Whenever a user enters data and clicks on the "Save" button in a form, the rules are triggered. A `NullPointerException` is thrown in `ExpressionService#getValueFromDbb` for all those forms in "Not Started" status whose item has a rule based on it. This happens because an _event_crf_ entry does not exist in the database for such forms and hence a _study_event_ cannot be found for these.
- This `NullPointerException` causes `map.get("expressionWithFixedOrdinals")` (which has been introduced in #3638) to be `null`. This `null` causes the Oops page to show when the code tries to use the value of `map.get("expressionWithFixedOrdinals")` for checking the syntax of the rule expression.