### PR TITLE
OC-21475 - Form submission error message correction

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/controller/openrosa/OpenRosaSubmissionController.java
+++ b/web/src/main/java/org/akaza/openclinica/controller/openrosa/OpenRosaSubmissionController.java
@@ -146,7 +146,7 @@ public class OpenRosaSubmissionController {
             return new ResponseEntity<String>(responseMessage, org.springframework.http.HttpStatus.CREATED);
         } else {
             logger.info("Submission contained errors. Sending error response");
-            return new ResponseEntity<String>(org.springframework.http.HttpStatus.NOT_ACCEPTABLE);
+            return new ResponseEntity<String>(org.springframework.http.HttpStatus.BAD_REQUEST);
         }
     }
 

--- a/web/src/main/java/org/akaza/openclinica/web/pform/OpenRosaServices.java
+++ b/web/src/main/java/org/akaza/openclinica/web/pform/OpenRosaServices.java
@@ -411,9 +411,10 @@ public class OpenRosaServices {
             LOGGER.debug("Successful OpenRosa submission");
             builder.entity("<OpenRosaResponse xmlns=\"http://openrosa.org/http/response\">" + "<message>success</message>" + "</OpenRosaResponse>");
             return builder.status(javax.ws.rs.core.Response.Status.CREATED).build();
-        } else if (responseEntity.getStatusCode().equals(org.springframework.http.HttpStatus.NOT_ACCEPTABLE)) {
+        } else if (responseEntity.getStatusCode().equals(org.springframework.http.HttpStatus.BAD_REQUEST)) {
             LOGGER.debug("Failed OpenRosa submission");
-            return builder.status(javax.ws.rs.core.Response.Status.NOT_ACCEPTABLE).build();
+            builder.entity("<OpenRosaResponse xmlns=\"http://openrosa.org/http/response\">" + "<message>Form contains errors. Please see fields marked in red.</message>" + "</OpenRosaResponse>");
+            return builder.status(javax.ws.rs.core.Response.Status.BAD_REQUEST).build();
         } else {
             LOGGER.debug("Failed OpenRosa submission with unhandled error");
             return builder.status(javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR).build();


### PR DESCRIPTION
After looking into the enketo source code, I found that it parses xml response and looks for `OpenRosaResponse > message` tag in it when the status code is 400 to look for explicit error messages from the server. The reason why I have to update the status code to 400 to successfully send our custom error message from the server. Please see the image attached.

![enketo_behavior](https://github.com/OpenClinica/OpenClinica/assets/114674072/c4668aca-b81c-4f31-9921-1b29435faeed)
