### PR TITLE
OC-21537 - Fix status issue for forbidden openrosa submission

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/controller/openrosa/OpenRosaSubmissionController.java
+++ b/web/src/main/java/org/akaza/openclinica/controller/openrosa/OpenRosaSubmissionController.java
@@ -174,7 +174,10 @@ public class OpenRosaSubmissionController {
         String pManageStatus = participantPortalRegistrar.getRegistrationStatus(studyOid).toString();
 
         // enabled or disabled
-        String participateStatus = pStatus.getValue().toString();
+        String participateStatus = "disabled";
+        if(pStatus != null){
+            participateStatus = pStatus.getValue().toString();
+        }
 
         // available, pending, frozen, or locked
         String studyStatus = study.getStatus().getName().toString();

--- a/web/src/main/java/org/akaza/openclinica/web/pform/OpenRosaServices.java
+++ b/web/src/main/java/org/akaza/openclinica/web/pform/OpenRosaServices.java
@@ -415,6 +415,9 @@ public class OpenRosaServices {
             LOGGER.debug("Failed OpenRosa submission");
             builder.entity("<OpenRosaResponse xmlns=\"http://openrosa.org/http/response\">" + "<message>Form contains errors. Please see fields marked in red.</message>" + "</OpenRosaResponse>");
             return builder.status(javax.ws.rs.core.Response.Status.BAD_REQUEST).build();
+        } else if (responseEntity.getStatusCode().equals(org.springframework.http.HttpStatus.NOT_ACCEPTABLE)) {
+            LOGGER.debug("Unacceptable OpenRosa submission");
+            return builder.status(javax.ws.rs.core.Response.Status.NOT_ACCEPTABLE).build();
         } else {
             LOGGER.debug("Failed OpenRosa submission with unhandled error");
             return builder.status(javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR).build();


### PR DESCRIPTION
`NOT_ACCEPTABLE (406)` status code was changed to `BAD_REQUEST (400)` for enketo to parse custom error message for OC-21537. But when submission is forbidden (case where participate is disable or study status other than available), `NOT_ACCEPTABLE` error code is thrown. This is just simple fix to add another conditional block to look for `NOT_ACCEPTABLE` error code in case of forbidden submission.

![OC-21537](https://github.com/OpenClinica/OpenClinica/assets/114674072/d159acf4-f50a-4300-975a-9f4a9cab97cf)
