### PR TITLE
OC-22736 - Fix - Links to Docx and PDF files are not Functioning Correctly

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/control/submit/DownloadAttachedFileServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/DownloadAttachedFileServlet.java
@@ -20,6 +20,7 @@ import org.akaza.openclinica.web.InsufficientPermissionException;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Locale;
 
@@ -81,7 +82,7 @@ public class DownloadAttachedFileServlet extends SecureController {
             File temp = new File(filePath,f.getName());            
             String canonicalPath= temp.getCanonicalPath();
             
-            if (canonicalPath.startsWith(filePath)) {
+            if (Paths.get(canonicalPath).startsWith(Paths.get(filePath))) {
             	;
             }else {
             	throw new RuntimeException("Traversal attempt - file path not allowed " + fileName);
@@ -129,7 +130,7 @@ public class DownloadAttachedFileServlet extends SecureController {
             String canonicalPath= file.getCanonicalPath();            
             String definedDownloadPath = Utils.getAttachedFileRootPath();
             
-            if(!(canonicalPath.startsWith(definedDownloadPath))) {
+            if(!(Paths.get(canonicalPath).startsWith(Paths.get(definedDownloadPath)))) {
             	throw new RuntimeException("Traversal attempt - file path not allowed " + fileName);
             }
         	

--- a/web/src/main/java/org/akaza/openclinica/control/submit/DownloadAttachedFileServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/DownloadAttachedFileServlet.java
@@ -20,7 +20,6 @@ import org.akaza.openclinica.web.InsufficientPermissionException;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Locale;
 
@@ -82,7 +81,7 @@ public class DownloadAttachedFileServlet extends SecureController {
             File temp = new File(filePath,f.getName());            
             String canonicalPath= temp.getCanonicalPath();
             
-            if (Paths.get(canonicalPath).startsWith(Paths.get(filePath))) {
+            if (canonicalPath.startsWith(filePath)) {
             	;
             }else {
             	throw new RuntimeException("Traversal attempt - file path not allowed " + fileName);
@@ -130,7 +129,7 @@ public class DownloadAttachedFileServlet extends SecureController {
             String canonicalPath= file.getCanonicalPath();            
             String definedDownloadPath = Utils.getAttachedFileRootPath();
             
-            if(!(Paths.get(canonicalPath).startsWith(Paths.get(definedDownloadPath)))) {
+            if(!(canonicalPath.startsWith(definedDownloadPath))) {
             	throw new RuntimeException("Traversal attempt - file path not allowed " + fileName);
             }
         	

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/viewStudySubjectAudit.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/viewStudySubjectAudit.jsp
@@ -369,7 +369,7 @@
                                                 <c:set var="path" value="${eventCRFAudit.oldValue}"/>
                                                 <c:set var="sep" value="\\"/>
                                                 <c:set var="sep2" value="\\\\"/>
-                                                <a href="DownloadAttachedFile?eventCRFId=<c:out value="${eventCRFAudit.eventCRFId}"/>&fileName=${fn:replace(fn:replace(path,'+','%2B'),sep,sep2)}"><c:out value="${eventCRFAudit.oldValue}"/></a>
+                                                <a href="DownloadAttachedFile?eventCRFId=<c:out value="${eventCRFAudit.eventCRFId}"/>&fileName=${fn:replace(fn:replace(fn:replace(path, '\\', '/'),'+','%2B'),sep,sep2)}"><c:out value="${eventCRFAudit.oldValue}"/></a>
                                             </c:when>
                                             <c:otherwise><c:out value="${eventCRFAudit.oldValue}"/></c:otherwise>
                                         </c:choose>
@@ -402,7 +402,7 @@
                                                 <c:set var="path" value="${eventCRFAudit.newValue}"/>
                                                 <c:set var="sep" value="\\"/>
                                                 <c:set var="sep2" value="\\\\"/>
-                                                <a href="DownloadAttachedFile?eventCRFId=<c:out value="${eventCRFAudit.eventCRFId}"/>&fileName=${fn:replace(fn:replace(path,'+','%2B'),sep,sep2)}"><c:out value="${eventCRFAudit.newValue}"/></a>
+                                                <a href="DownloadAttachedFile?eventCRFId=<c:out value="${eventCRFAudit.eventCRFId}"/>&fileName=${fn:replace(fn:replace(fn:replace(path, '\\', '/'),'+','%2B'),sep,sep2)}"><c:out value="${eventCRFAudit.newValue}"/></a>
                                             </c:when>
                                             <c:otherwise><c:out value="${eventCRFAudit.newValue}"/></c:otherwise>
                                         </c:choose>

--- a/web/src/main/webapp/WEB-INF/jsp/submit/showFixedItemInput.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/showFixedItemInput.jsp
@@ -1,6 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 
 <jsp:useBean scope="request" id="section" class="org.akaza.openclinica.bean.submit.DisplaySectionBean" />
 <jsp:useBean scope="request" id="displayItem" class="org.akaza.openclinica.bean.submit.DisplayItemBean" />
@@ -30,7 +31,7 @@
 	</c:when>
 	<c:otherwise>
 		<c:set var="prefilename" value="${inputTxtValue}"/>
-		<a href="DownloadAttachedFile?eventCRFId=<c:out value="${section.eventCRF.id}"/>&fileName=<c:out value="${fn:replace(prefilename,'+','%2B')}"/>" id="a<c:out value="${itemId}"/>"><c:out value="${inputTxtValue}"/></a>
+		<a href="DownloadAttachedFile?eventCRFId=<c:out value="${section.eventCRF.id}"/>&fileName=<c:out value="${fn:replace(fn:replace(prefilename, '\\', '/'),'+','%2B')}"/>" id="a<c:out value="${itemId}"/>"><c:out value="${inputTxtValue}"/></a>
 		<c:choose>
 		<c:when test="${fn:contains(inputTxtValue, 'fileNotFound#')}">
 			<del><c:out value="${fn:substringAfter(inputTxtValue,'fileNotFound#')}"/></del>

--- a/web/src/main/webapp/WEB-INF/jsp/submit/showGroupItemInput.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/showGroupItemInput.jsp
@@ -1,7 +1,6 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 <fmt:setBundle basename="org.akaza.openclinica.i18n.format" var="resformat"/>
 <fmt:setBundle basename="org.akaza.openclinica.i18n.words" var="resword"/>
 <fmt:setBundle basename="org.akaza.openclinica.i18n.notes" var="restext"/>
@@ -106,7 +105,7 @@ function replaceSwitch(eventCRFId,itemId,id,attribute,str1,str2,filename,filePat
 	var up = document.getElementById('up'+itemId);
 	<%-- uploadLink is different from showItemInput.jsp --%>
 	var uploadLink = 'UploadFile?submitted=no&inputName=' + itemId;
-	var downloadLink = 'DownloadAttachedFile?eventCRFId=' + eventCRFId + '&fileName=' + filePathName;
+	var downloadLink = 'DownloadAttachedFile?eventCRFId=' + eventCRFId + '&fileName=' + filePathName.replace(/\\/g,"/");
 	if(rp.getAttribute('value')=="<fmt:message key="replace" bundle="${resword}"/>") {
 		if(a) {
 			div.appendChild(a);
@@ -170,7 +169,7 @@ function removeSwitch(eventCRFId,itemId,id,attribute,str1,str2,filename,filePath
 		//which means this is a single item with itemId being a number
 		input = document.getElementById('input'+itemId);
 	}
-	var downloadLink = 'DownloadAttachedFile?eventCRFId=' + eventCRFId + '&fileName=' + filePathName;
+	var downloadLink = 'DownloadAttachedFile?eventCRFId=' + eventCRFId + '&fileName=' + filePathName.replace(/\\/g,"/");
 	if(rm.getAttribute('value')=='<fmt:message key="remove" bundle="${resword}"/>') {
 		input.setAttribute("value","");
 		if(a) {
@@ -367,7 +366,7 @@ function switchStr(itemId, id,attribute,str1,str2) {
 		</c:when>
 		<c:otherwise>
 			<c:set var="prefilename" value="${displayItem.data.value}"/>
-			<a href="DownloadAttachedFile?eventCRFId=<c:out value="${section.eventCRF.id}"/>&fileName=<c:out value="${fn:replace(prefilename,'+','%2B')}"/>" id="a<c:out value="${inputName}"/>"><c:out value="${inputTxtValue}"/></a>
+			<a href="DownloadAttachedFile?eventCRFId=<c:out value="${section.eventCRF.id}"/>&fileName=<c:out value="${fn:replace(fn:replace(prefilename, '\\', '/'),'+','%2B')}"/>" id="a<c:out value="${inputName}"/>"><c:out value="${inputTxtValue}"/></a>
 			<input type="hidden" id="hidft<c:out value="${inputName}"/>" name="fileText<c:out value="${inputName}"/>" disabled class="disabled">
 			<input type="hidden" id="hidup<c:out value="${inputName}"/>" name="uploadFile<c:out value="${inputName}"/>" value="<fmt:message key="click_to_upload" bundle="${resword}"/>" onClick="javascript:openDocWindow('UploadFile?submitted=no&itemId=<c:out value="${itemId}"/>&inputName=<c:out value="${inputName}"/>')">
 		</div><br>

--- a/web/src/main/webapp/WEB-INF/jsp/submit/showGroupItemInputMonitor.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/showGroupItemInputMonitor.jsp
@@ -181,7 +181,7 @@
 			<c:set var="filename" value="${displayItem.data.value}"/>
 			<c:set var="sep" value="\\"/>
             <c:set var="sep2" value="\\\\"/>
-			<a href="DownloadAttachedFile?eventCRFId=<c:out value="${section.eventCRF.id}"/>&fileName=${fn:replace(fn:replace(filename,'+','%2B'),sep,sep2)}" id="a<c:out value="${itemId}"/>"><c:out value="${inputTxtValue}"/></a>
+			<a href="DownloadAttachedFile?eventCRFId=<c:out value="${section.eventCRF.id}"/>&fileName=${fn:replace(fn:replace(fn:replace(filename, '\\', '/'),'+','%2B'),sep,sep2)}" id="a<c:out value="${itemId}"/>"><c:out value="${inputTxtValue}"/></a>
 		</c:otherwise>
 		</c:choose>
 	</c:otherwise>

--- a/web/src/main/webapp/WEB-INF/jsp/submit/showItemInput.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/showItemInput.jsp
@@ -147,7 +147,7 @@ form element in red --%>
 		</c:when>
 		<c:otherwise>
 			<c:set var="prefilename" value="${pathAndName}"/>
-			<a href="DownloadAttachedFile?eventCRFId=<c:out value="${section.eventCRF.id}"/>&fileName=<c:out value="${fn:replace(prefilename,'+','%2B')}"/>" id="a<c:out value="${itemId}"/>"><c:out value="${inputTxtValue}"/></a>
+			<a href="DownloadAttachedFile?eventCRFId=<c:out value="${section.eventCRF.id}"/>&fileName=<c:out value="${fn:replace(fn:replace(prefilename, '\\\\', '/'),'+','%2B')}"/>" id="a<c:out value="${itemId}"/>"><c:out value="${inputTxtValue}"/></a>
 		</div><br>
 		<input id="rp<c:out value="${itemId}"/>" type="button" value="<fmt:message key="replace" bundle="${resword}"/>" onClick="replaceSwitch('<c:out value="${section.eventCRF.id}"/>','<c:out value="${itemId}"/>','rp','value','Replace','Cancel Replace','<c:out value="${inputTxtValue}"/>','<c:out value="${pathAndName}"/>','found')">
 		<input id="rm<c:out value="${itemId}"/>" type="button" value="<fmt:message key="remove" bundle="${resword}"/>" onClick="removeSwitch('<c:out value="${section.eventCRF.id}"/>','<c:out value="${itemId}"/>','rm','value','Remove','Cancel Remove','<c:out value="${inputTxtValue}"/>','<c:out value="${pathAndName}"/>','found')">

--- a/web/src/main/webapp/WEB-INF/jsp/submit/showItemInputMonitor.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/showItemInputMonitor.jsp
@@ -141,7 +141,7 @@ form element in red --%>
 			<c:set var="filename" value="${displayItem.data.value}"/>
 			<c:set var="sep" value="\\"/>
             <c:set var="sep2" value="\\\\"/>
-			<a href="DownloadAttachedFile?eventCRFId=<c:out value="${section.eventCRF.id}"/>&&fileName=${fn:replace(fn:replace(filename,'+','%2B'),sep,sep2)}" id="a<c:out value="${itemId}"/>"><c:out value="${inputTxtValue}"/></a>
+			<a href="DownloadAttachedFile?eventCRFId=<c:out value="${section.eventCRF.id}"/>&&fileName=${fn:replace(fn:replace(fn:replace(filename, '\\', '/'),'+','%2B'),sep,sep2)}" id="a<c:out value="${itemId}"/>"><c:out value="${inputTxtValue}"/></a>
 		</c:otherwise>
 		</c:choose>
 	</c:otherwise>

--- a/web/src/main/webapp/WEB-INF/jsp/submit/showItemInputToolTipsJS.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/showItemInputToolTipsJS.jsp
@@ -106,7 +106,7 @@ function replaceSwitch(eventCRFId,itemId,id,attribute,str1,str2,filename,pathAnd
 	var ft = document.getElementById('ft'+itemId);
 	var up = document.getElementById('up'+itemId);
 	var uploadLink = 'UploadFile?submitted=no&itemId=' + itemId;
-	var downloadLink = 'DownloadAttachedFile?eventCRFId=' + eventCRFId + '&fileName=' + pathAndName;
+	var downloadLink = 'DownloadAttachedFile?eventCRFId=' + eventCRFId + '&fileName=' + pathAndName.replace(/\\/g,"/");
 	if(rp.getAttribute('value')=="<fmt:message key="replace" bundle="${resword}"/>") {
 		if(a) {
 			div.appendChild(a);
@@ -166,7 +166,7 @@ function removeSwitch(eventCRFId,itemId,id,attribute,str1,str2,filename,pathAndN
 	var ft = document.getElementById('ft'+itemId);
 	var up = document.getElementById('up'+itemId);
 	var input = document.getElementById('input'+itemId);
-	var downloadLink = 'DownloadAttachedFile?eventCRFId=' + eventCRFId + '&fileName=' + pathAndName;
+	var downloadLink = 'DownloadAttachedFile?eventCRFId=' + eventCRFId + '&fileName=' + pathAndName.replace(/\\/g,"/");
 	if(rm.getAttribute('value')=='<fmt:message key="remove" bundle="${resword}"/>') {
 		input.setAttribute("value","");
 		if(a) {


### PR DESCRIPTION
- Using Java `Paths` to compare file paths instead of simple string comparison while checking for traversal attempts
- Changing `\\` to `/` in file download URLs in forms JSP for the `fileName` parameter