### PR TITLE
Updating previously added code to work with windows/linux paths regardless of the datainfo.properties configuration

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/control/submit/DownloadAttachedFileServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/DownloadAttachedFileServlet.java
@@ -37,20 +37,6 @@ public class DownloadAttachedFileServlet extends SecureController {
     public void mayProceed() throws InsufficientPermissionException {
         Locale locale = LocaleResolver.getLocale(request);
         FormProcessor fp = new FormProcessor(request);
-/*        int eventCRFId = fp.getInt("eventCRFId");
-        EventCRFDAO edao = new EventCRFDAO(sm.getDataSource());
-
-        if (eventCRFId > 0) {
-            if (!entityIncluded(eventCRFId, ub.getName(), edao, sm.getDataSource())) {
-                request.setAttribute("downloadStatus", "false");
-                addPageMessage(respage.getString("you_not_have_permission_download_attached_file"));
-                throw new InsufficientPermissionException(Page.DOWNLOAD_ATTACHED_FILE, resexception.getString("no_permission"), "1");
-            }
-        } else {
-            request.setAttribute("downloadStatus", "false");
-            addPageMessage(respage.getString("you_not_have_permission_download_attached_file"));
-            throw new InsufficientPermissionException(Page.DOWNLOAD_ATTACHED_FILE, resexception.getString("no_permission"), "1");
-        }*/
 
         if (ub.isSysAdmin()) {
             return;
@@ -181,7 +167,7 @@ public class DownloadAttachedFileServlet extends SecureController {
     }
 
     private boolean startsWithIgnoringSlashes(String str1, String str2) {
-        // Replace all forward slashes with empty strings
+        // Replace all forward slashes & back slashes with empty strings
         String normalizedStr1 = str1.replace("/", "").replace("\\", "");
         String normalizedStr2 = str2.replace("/", "").replace("\\", "");
 

--- a/web/src/main/java/org/akaza/openclinica/control/submit/DownloadAttachedFileServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/DownloadAttachedFileServlet.java
@@ -69,24 +69,31 @@ public class DownloadAttachedFileServlet extends SecureController {
         FormProcessor fp = new FormProcessor(request);
         String filePathName = "";
         String fileName = fp.getString("fileName");
+        logger.debug("fileName .... " + fileName);
         File f = new File(fileName);
-              
+
         if (fileName != null && fileName.length() > 0) {
-            int parentStudyId = currentStudy.getParentStudyId();           
+            int parentStudyId = currentStudy.getParentStudyId();
             String testPath = Utils.getAttachedFileRootPath();
+            logger.debug("testPath .... " + testPath);
             String tail = File.separator + f.getName();
+            logger.debug("tail .... " + tail);
             String testName = testPath + currentStudy.getOid() + tail;
-            
-            String filePath = testPath + currentStudy.getOid() +File.separator;            
-            File temp = new File(filePath,f.getName());            
+            logger.debug("testName .... " + testName);
+
+            String filePath = testPath + currentStudy.getOid() +File.separator;
+            logger.debug("filePath .... " + filePath);
+            File temp = new File(filePath,f.getName());
             String canonicalPath= temp.getCanonicalPath();
-            
-            if (canonicalPath.startsWith(filePath)) {
-            	;
+            logger.debug("canonicalPath .... " + canonicalPath);
+            logger.debug("canonicalPath.startsWith(filePath) .... " + canonicalPath);
+
+            if (startsWithIgnoringSlashes(canonicalPath,filePath)) {
+                ;
             }else {
-            	throw new RuntimeException("Traversal attempt - file path not allowed " + fileName);
+                throw new RuntimeException("Traversal attempt - file path not allowed " + fileName);
             }
-            
+
             if (temp.exists()) {
                 filePathName = testName;
                 logger.info(currentStudy.getName() + " existing filePathName=" + filePathName);
@@ -116,25 +123,26 @@ public class DownloadAttachedFileServlet extends SecureController {
         logger.info("filePathName=" + filePathName + " fileName=" + fileName);
         File file = null;
         if(filePathName != null && filePathName.trim().length() >0) {
-        	file = new File(filePathName);
+            file = new File(filePathName);
         }else {
-        	file = new File(fileName);
+            file = new File(fileName);
         }
-        
-        if (file != null && file.exists()) {           
+
+        if (file != null && file.exists()) {
             /*
              *  try to use the passed in the existing file
-             *  OC-17868 remove any possible path traversal, will make sure only download files from defined download folder            
-             */                 	                    
-            String canonicalPath= file.getCanonicalPath();            
+             *  OC-17868 remove any possible path traversal, will make sure only download files from defined download folder
+             */
+            String canonicalPath= file.getCanonicalPath();
             String definedDownloadPath = Utils.getAttachedFileRootPath();
-            
-            if(!(canonicalPath.startsWith(definedDownloadPath))) {
-            	throw new RuntimeException("Traversal attempt - file path not allowed " + fileName);
+
+
+            if (!startsWithIgnoringSlashes(canonicalPath,definedDownloadPath)) {
+                throw new RuntimeException("Traversal attempt - file path not allowed " + fileName);
             }
-        	
+
         }
-        
+
         if (!file.exists() || file.length() <= 0) {
             addPageMessage("File " + filePathName + " " + respage.getString("not_exist"));
         } else {
@@ -170,6 +178,18 @@ public class DownloadAttachedFileServlet extends SecureController {
                 }
             }
         }
+    }
+
+    private boolean startsWithIgnoringSlashes(String str1, String str2) {
+        // Replace all forward slashes with empty strings
+        String normalizedStr1 = str1.replace("/", "").replace("\\", "");
+        String normalizedStr2 = str2.replace("/", "").replace("\\", "");
+
+        logger.debug("normalizedStr1 .... {}", normalizedStr1);
+        logger.debug("normalizedStr2 .... {}", normalizedStr2);
+
+        // Compare the normalized strings
+        return normalizedStr1.startsWith(normalizedStr2);
     }
 
 }


### PR DESCRIPTION
In datainfo.properties we define 
`filePath=${catalina.home}/${WEBAPP.lower}.data/`
This path can be configured with either windows paths or linux paths on a windows box. Looks like atleast one of the customer we have has linux paths configured on their windows installation. 

I am applying a fix to a code change that was done in 3.17.0 that ensures allowed paths are only accessed. 